### PR TITLE
fix: undefined reference to XShapeCombineRectangles

### DIFF
--- a/plugins/shutdown/shutdown.pro
+++ b/plugins/shutdown/shutdown.pro
@@ -1,7 +1,7 @@
 
 include(../../interfaces/interfaces.pri)
 
-QT              += widgets svg
+QT              += widgets svg dbus
 TEMPLATE         = lib
 CONFIG          += plugin c++11 link_pkgconfig
 PKGCONFIG       +=

--- a/plugins/system-tray/system-tray.pro
+++ b/plugins/system-tray/system-tray.pro
@@ -4,7 +4,7 @@ include(../../interfaces/interfaces.pri)
 QT              += widgets gui core dbus x11extras svg
 TEMPLATE         = lib
 CONFIG          += plugin c++11 link_pkgconfig
-PKGCONFIG       += xcb xcb-image xcb-icccm xcb-composite xtst
+PKGCONFIG       += xcb xcb-image xcb-icccm xcb-composite xtst xext x11
 
 TARGET          = $$qtLibraryTarget(system-tray)
 DESTDIR          = $$_PRO_FILE_PWD_/../


### PR DESCRIPTION
openSUSE use --as-needed link option by default. 
made added the X11 libraries to the modules themselves.