### PR TITLE
Fix for 12 AM during 12 PM

### DIFF
--- a/plugins/datetime/datetimewidget.cpp
+++ b/plugins/datetime/datetimewidget.cpp
@@ -167,7 +167,7 @@ void DatetimeWidget::paintEvent(QPaintEvent *e)
             const int tips_height = tips_width / 2;
 
             QPixmap tips;
-            if (current.time().hour() > 12)
+            if (current.time().hour() > 11)
                 tips = loadSvg(":/icons/resources/icons/tips-pm.svg", QSize(tips_width, tips_height));
             else
                 tips = loadSvg(":/icons/resources/icons/tips-am.svg", QSize(tips_width, tips_height));


### PR DESCRIPTION
At 12 PM the dock would show that the time is 12 AM! Here's the gif photo of it....
![deepin-screen-recorder_select area_20180105115951](https://user-images.githubusercontent.com/33563064/34602194-15038cec-f229-11e7-8cbd-184c0d81f3e6.gif)

