### PR TITLE
fix can not correctly sort plugin

### DIFF
--- a/frame/controller/dockitemcontroller.cpp
+++ b/frame/controller/dockitemcontroller.cpp
@@ -314,7 +314,7 @@ void DockItemController::pluginItemInserted(PluginsItem *item)
             PluginsItem *pItem = static_cast<PluginsItem *>(m_itemList[i]);
             Q_ASSERT(pItem);
 
-            if (itemSortKey <= pItem->itemSortKey())
+            if (pItem->itemSortKey() != -1 && itemSortKey > pItem->itemSortKey())
                 continue;
             insertIndex = i;
             break;


### PR DESCRIPTION
自己写的dock插件虽然实现了itemSortKey()和setSortKey()，仍然不能正确排序，修改了下dock源代码，排序相对正常了
另外，系统自带的插件基本上没有实现setSortKey()，这样不能自定义顺序，不知官方什么时候修复下