### PR TITLE
fix: dock position and size is wrong on multiple screens and the scre…

### DIFF
--- a/frame/dbus/dbusdisplay.h
+++ b/frame/dbus/dbusdisplay.h
@@ -107,30 +107,16 @@ public:
     inline QString primary() const
     { return qvariant_cast< QString >(property("Primary")); }
 
-    Q_PROPERTY(DisplayRect PrimaryRect READ primaryRect NOTIFY PrimaryRectChanged)
+    Q_PROPERTY(DisplayRect PrimaryRect READ primaryRawRect NOTIFY PrimaryRectChanged)
     inline DisplayRect primaryRawRect() const {
         return qvariant_cast< DisplayRect >(property("PrimaryRect"));
     }
-    inline DisplayRect primaryRect() const
-    {
-        const qreal scale = qApp->devicePixelRatio();
 
-        DisplayRect dr = primaryRawRect();
-        dr.width = std::round(qreal(dr.width) / scale);
-        dr.height = std::round(qreal(dr.height) / scale);
-
-        return dr;
-    }
-
-    Q_PROPERTY(ushort ScreenHeight READ screenHeight NOTIFY ScreenHeightChanged)
-    inline ushort screenHeight() const
-    { return screenRawHeight() / qApp->devicePixelRatio(); }
+    Q_PROPERTY(ushort ScreenHeight READ screenRawHeight NOTIFY ScreenHeightChanged)
     inline ushort screenRawHeight() const
     { return qreal(qvariant_cast< ushort >(property("ScreenHeight"))); }
 
-    Q_PROPERTY(ushort ScreenWidth READ screenWidth NOTIFY ScreenWidthChanged)
-    inline ushort screenWidth() const
-    { return screenRawWidth() / qApp->devicePixelRatio(); }
+    Q_PROPERTY(ushort ScreenWidth READ screenRawWidth NOTIFY ScreenWidthChanged)
     inline ushort screenRawWidth() const
     { return qreal(qvariant_cast< ushort >(property("ScreenWidth"))); }
 

--- a/frame/util/docksettings.h
+++ b/frame/util/docksettings.h
@@ -65,15 +65,13 @@ public:
     inline HideMode hideMode() const { return m_hideMode; }
     inline HideState hideState() const { return m_hideState; }
     inline Position position() const { return m_position; }
-    inline int screenHeight() const { return m_displayInter->screenHeight(); }
-    inline int screenWidth() const { return m_displayInter->screenWidth(); }
     inline int screenRawHeight() const { return m_screenRawHeight; }
     inline int screenRawWidth() const { return m_screenRawWidth; }
     inline int expandTimeout() const { return m_dockInter->showTimeout(); }
     inline int narrowTimeout() const { return 100; }
     inline bool autoHide() const { return m_autoHide; }
     inline bool isMaxSize() const { return m_isMaxSize; }
-    inline const QRect primaryRect() const { return m_primaryRect; }
+    const QRect primaryRect() const;
     inline const QRect primaryRawRect() const { return m_primaryRawRect; }
     inline const QRect frontendWindowRect() const { return m_frontendRect; }
     inline const QSize windowSize() const { return m_mainWindowSize; }
@@ -134,7 +132,6 @@ private:
     HideMode m_hideMode;
     HideState m_hideState;
     DisplayMode m_displayMode;
-    QRect m_primaryRect;
     QRect m_primaryRawRect;
     QRect m_frontendRect;
     QSize m_mainWindowSize;

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -42,18 +42,20 @@ using org::kde::StatusNotifierWatcher;
 
 const QPoint rawXPosition(const QPoint &scaledPos)
 {
-    QRect g = qApp->primaryScreen()->geometry();
+    QScreen *s = qApp->primaryScreen();
     for (auto *screen : qApp->screens())
     {
         const QRect &sg = screen->geometry();
         if (sg.contains(scaledPos))
         {
-            g = sg;
+            s = screen;
             break;
         }
     }
 
-    return g.topLeft() + (scaledPos - g.topLeft()) * qApp->devicePixelRatio();
+    const QRect &g = s->geometry();
+
+    return g.topLeft() + (scaledPos - g.topLeft()) * s->devicePixelRatio();
 }
 
 const QPoint scaledPos(const QPoint &rawXPos)
@@ -176,6 +178,25 @@ void MainWindow::showEvent(QShowEvent *e)
     m_platformWindowHandle.setEnableBlurWindow(false);
     m_platformWindowHandle.setShadowOffset(QPoint());
     m_platformWindowHandle.setShadowRadius(0);
+
+    connect(qGuiApp, &QGuiApplication::primaryScreenChanged,
+            windowHandle(), [this] (QScreen *new_screen) {
+        QScreen *old_screen = windowHandle()->screen();
+        windowHandle()->setScreen(new_screen);
+        // 屏幕变化后可能导致控件缩放比变化，此时应该重设控件位置大小
+        // 比如：窗口大小为 100 x 100, 显示在缩放比为 1.0 的屏幕上，此时窗口的真实大小 = 100x100
+        // 随后窗口被移动到了缩放比为 2.0 的屏幕上，应该将真实大小改为 200x200。另外，只能使用
+        // QPlatformWindow直接设置大小来绕过QWidget和QWindow对新旧geometry的比较。
+        const qreal scale = devicePixelRatioF();
+        const QPoint screenPos = new_screen->geometry().topLeft();
+        const QPoint posInScreen = this->pos() - old_screen->geometry().topLeft();
+        const QPoint pos = screenPos + posInScreen * scale;
+        const QSize size = this->size() * scale;
+
+        windowHandle()->handle()->setGeometry(QRect(pos, size));
+    }, Qt::UniqueConnection);
+
+    windowHandle()->setScreen(qGuiApp->primaryScreen());
 }
 
 void MainWindow::mousePressEvent(QMouseEvent *e)


### PR DESCRIPTION
…ens have different device scale ratio

dock跟随主屏显示，但却没有将主窗口的screen随着主屏的改动而更改。当多屏开启不同缩放比显示时，随着屏幕模式的切换，dock到达新的屏幕后，大小和位置会出错。