### PR TITLE
refactor: use QWidget::devicePixelRatio to replace QApplication::devi…

### DIFF
--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -511,7 +511,7 @@ bool AppItem::hasAttention() const
 
 QPoint AppItem::appIconPosition() const
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const QRectF itemRect = rect();
     const QRectF iconRect = m_appIcon.rect();
     const qreal iconX = itemRect.center().x() - iconRect.center().x() / ratio;
@@ -547,9 +547,9 @@ void AppItem::refershIcon()
     const int iconSize = qMin(width(), height());
 
     if (DockDisplayMode == Efficient)
-        m_appIcon = ThemeAppIcon::getIcon(icon, iconSize * 0.7);
+        m_appIcon = ThemeAppIcon::getIcon(icon, iconSize * 0.7, devicePixelRatioF());
     else
-        m_appIcon = ThemeAppIcon::getIcon(icon, iconSize * 0.8);
+        m_appIcon = ThemeAppIcon::getIcon(icon, iconSize * 0.8, devicePixelRatioF());
 
     if (m_appIcon.isNull()) {
         if (m_retryTimes < 5) {
@@ -602,7 +602,7 @@ void AppItem::playSwingEffect()
     stopSwingEffect();
 
     QPair<QGraphicsView *, QGraphicsItemAnimation *> pair =  SwingEffect(
-            this, m_appIcon, rect(), qApp->devicePixelRatio());
+            this, m_appIcon, rect(), devicePixelRatioF());
 
     m_swingEffectView = pair.first;
     m_itemAnimation = pair.second;

--- a/frame/item/launcheritem.cpp
+++ b/frame/item/launcheritem.cpp
@@ -48,11 +48,11 @@ void LauncherItem::refershIcon()
     const int iconSize = qMin(width(), height());
     if (DockDisplayMode == Efficient)
     {
-        m_smallIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.7);
-        m_largeIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.9);
+        m_smallIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.7, devicePixelRatioF());
+        m_largeIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.9, devicePixelRatioF());
     } else {
-        m_smallIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.6);
-        m_largeIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.8);
+        m_smallIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.6, devicePixelRatioF());
+        m_largeIcon = ThemeAppIcon::getIcon("deepin-launcher", iconSize * 0.8, devicePixelRatioF());
     }
 
     update();
@@ -69,7 +69,7 @@ void LauncherItem::paintEvent(QPaintEvent *e)
 
     const QPixmap pixmap = DockDisplayMode == Fashion ? m_largeIcon : m_smallIcon;
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const int iconX = rect().center().x() - pixmap.rect().center().x() / ratio;
     const int iconY = rect().center().y() - pixmap.rect().center().y() / ratio;
 

--- a/frame/util/docksettings.cpp
+++ b/frame/util/docksettings.cpp
@@ -22,6 +22,7 @@
 #include "docksettings.h"
 #include "panel/mainpanel.h"
 #include "item/appitem.h"
+#include "util/utils.h"
 
 #include <QDebug>
 #include <QX11Info>
@@ -68,7 +69,7 @@ DockSettings::DockSettings(QWidget *parent)
     m_hideMode = Dock::HideMode(m_dockInter->hideMode());
     m_hideState = Dock::HideState(m_dockInter->hideState());
     m_iconSize = m_dockInter->iconSize();
-    AppItem::setIconBaseSize(m_iconSize * qApp->devicePixelRatio());
+    AppItem::setIconBaseSize(m_iconSize * dockRatio());
     DockItem::setDockPosition(m_position);
     qApp->setProperty(PROP_POSITION, QVariant::fromValue(m_position));
     DockItem::setDockDisplayMode(m_displayMode);
@@ -364,7 +365,7 @@ void DockSettings::iconSizeChanged()
 {
 //    qDebug() << Q_FUNC_INFO;
     m_iconSize = m_dockInter->iconSize();
-    AppItem::setIconBaseSize(m_iconSize * qApp->devicePixelRatio());
+    AppItem::setIconBaseSize(m_iconSize * dockRatio());
 
     calculateWindowConfig();
 
@@ -432,7 +433,7 @@ void DockSettings::primaryScreenChanged()
 void DockSettings::resetFrontendGeometry()
 {
     const QRect r = windowRect(m_position);
-    const qreal ratio = qApp->devicePixelRatio();
+    const qreal ratio = dockRatio();
     const QPoint p = rawXPosition(r.topLeft());
     const uint w = r.width() * ratio;
     const uint h = r.height() * ratio;
@@ -540,7 +541,7 @@ void DockSettings::onFashionTraySizeChanged(const QSize &traySize)
 
 void DockSettings::calculateWindowConfig()
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = dockRatio();
     const int defaultHeight = std::round(AppItem::itemBaseHeight() / ratio);
     const int defaultWidth = std::round(AppItem::itemBaseWidth() / ratio);
 
@@ -622,4 +623,11 @@ void DockSettings::gtkIconThemeChanged()
 {
     qDebug() << Q_FUNC_INFO;
     m_itemController->refershItemsIcon();
+}
+
+qreal DockSettings::dockRatio() const
+{
+    QScreen const *screen = Utils::screenAtByScaled(m_frontendRect.center());
+
+    return screen ? screen->devicePixelRatio() : qApp->devicePixelRatio();
 }

--- a/frame/util/docksettings.h
+++ b/frame/util/docksettings.h
@@ -80,6 +80,7 @@ public:
 
     const QSize panelSize() const;
     const QRect windowRect(const Position position, const bool hide = false) const;
+    qreal dockRatio() const;
 
     void showDockSettingsMenu();
 

--- a/frame/util/themeappicon.cpp
+++ b/frame/util/themeappicon.cpp
@@ -38,9 +38,8 @@ ThemeAppIcon::~ThemeAppIcon()
 
 }
 
-const QPixmap ThemeAppIcon::getIcon(const QString iconName, const int size)
+const QPixmap ThemeAppIcon::getIcon(const QString iconName, const int size, const qreal ratio)
 {
-    const auto ratio = qApp->devicePixelRatio();
     QPixmap pixmap;
     QString key;
 

--- a/frame/util/themeappicon.h
+++ b/frame/util/themeappicon.h
@@ -31,7 +31,7 @@ public:
     explicit ThemeAppIcon(QObject *parent = 0);
     ~ThemeAppIcon();
 
-    static const QPixmap getIcon(const QString iconName, const int size);
+    static const QPixmap getIcon(const QString iconName, const int size, const qreal ratio);
 };
 
 #endif // THEMEAPPICON_H

--- a/frame/util/utils.h
+++ b/frame/util/utils.h
@@ -1,6 +1,7 @@
 #include <QPixmap>
 #include <QImageReader>
 #include <QApplication>
+#include <QScreen>
 
 namespace Utils {
     static QPixmap renderSVG(const QString &path, const QSize &size) {
@@ -18,5 +19,27 @@ namespace Utils {
     }
 
     return pixmap;
+    }
+
+    static QScreen * screenAt(const QPoint &point) {
+        for (QScreen *screen : qApp->screens()) {
+            const QRect r { screen->geometry() };
+            const QRect rect { r.topLeft(), r.size() * screen->devicePixelRatio() };
+            if (rect.contains(point)) {
+                return screen;
+            }
+        }
+
+        return nullptr;
+    }
+
+    static QScreen * screenAtByScaled(const QPoint &point) {
+        for (QScreen *screen : qApp->screens()) {
+            if (screen->geometry().contains(point)) {
+                return screen;
+            }
+        }
+
+        return nullptr;
     }
 }

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -21,6 +21,7 @@
 
 #include "mainwindow.h"
 #include "panel/mainpanel.h"
+#include "util/utils.h"
 
 #include <QDebug>
 #include <QEvent>
@@ -42,36 +43,22 @@ using org::kde::StatusNotifierWatcher;
 
 const QPoint rawXPosition(const QPoint &scaledPos)
 {
-    QScreen *s = qApp->primaryScreen();
-    for (auto *screen : qApp->screens())
-    {
-        const QRect &sg = screen->geometry();
-        if (sg.contains(scaledPos))
-        {
-            s = screen;
-            break;
-        }
-    }
+    QScreen const * screen = Utils::screenAtByScaled(scaledPos);
 
-    const QRect &g = s->geometry();
-
-    return g.topLeft() + (scaledPos - g.topLeft()) * s->devicePixelRatio();
+    return screen ? screen->geometry().topLeft() +
+                        (scaledPos - screen->geometry().topLeft()) *
+                            screen->devicePixelRatio()
+                  : scaledPos;
 }
 
 const QPoint scaledPos(const QPoint &rawXPos)
 {
-    QRect g = qApp->primaryScreen()->geometry();
-    for (auto *screen : qApp->screens())
-    {
-        const QRect &sg = screen->geometry();
-        if (sg.contains(rawXPos))
-        {
-            g = sg;
-            break;
-        }
-    }
+    QScreen const * screen = Utils::screenAt(rawXPos);
 
-    return g.topLeft() + (rawXPos - g.topLeft()) / qApp->devicePixelRatio();
+    return screen
+               ? screen->geometry().topLeft() +
+                     (rawXPos - screen->geometry().topLeft()) / screen->devicePixelRatio()
+               : rawXPos;
 }
 
 MainWindow::MainWindow(QWidget *parent)

--- a/plugins/datetime/datetimewidget.cpp
+++ b/plugins/datetime/datetimewidget.cpp
@@ -73,7 +73,7 @@ void DatetimeWidget::paintEvent(QPaintEvent *e)
 {
     Q_UNUSED(e);
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const Dock::DisplayMode displayMode = qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>();
     const Dock::Position position = qApp->property(PROP_POSITION).value<Dock::Position>();
     const QDateTime current = QDateTime::currentDateTime();
@@ -188,7 +188,7 @@ void DatetimeWidget::paintEvent(QPaintEvent *e)
 
 const QPixmap DatetimeWidget::loadSvg(const QString &fileName, const QSize size)
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap(size * ratio);
     QSvgRenderer renderer(fileName);

--- a/plugins/network/item/applet/accesspointwidget.cpp
+++ b/plugins/network/item/applet/accesspointwidget.cpp
@@ -52,7 +52,7 @@ AccessPointWidget::AccessPointWidget()
     m_securityPixmap = Utils::renderSVG(":/wireless/resources/wireless/security.svg", QSize(16, 16));
     m_securityIconSize = m_securityPixmap.size();
     m_securityLabel->setPixmap(m_securityPixmap);
-    m_securityLabel->setFixedSize(m_securityIconSize / qApp->devicePixelRatio());
+    m_securityLabel->setFixedSize(m_securityIconSize / devicePixelRatioF());
 
     QHBoxLayout *infoLayout = new QHBoxLayout;
     infoLayout->addWidget(m_securityLabel);

--- a/plugins/network/item/applet/wirelesslist.cpp
+++ b/plugins/network/item/applet/wirelesslist.cpp
@@ -53,7 +53,7 @@ WirelessList::WirelessList(WirelessDevice *deviceIter, QWidget *parent)
 {
     setFixedHeight(WIDTH);
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     QPixmap iconPix = QIcon::fromTheme("notification-network-wireless-full").pixmap(QSize(48, 48) * ratio);
     iconPix.setDevicePixelRatio(ratio);
 

--- a/plugins/network/item/wireditem.cpp
+++ b/plugins/network/item/wireditem.cpp
@@ -72,7 +72,7 @@ void WiredItem::paintEvent(QPaintEvent *e)
     QWidget::paintEvent(e);
 
     QPainter painter(this);
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const QRectF &rf = QRectF(rect());
     const QRectF &rfp = QRectF(m_icon.rect());
     const int x = rf.center().x() - rfp.center().x() / ratio;
@@ -104,7 +104,7 @@ void WiredItem::reloadIcon()
 
 //    const Dock::DisplayMode displayMode = qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>();
     const Dock::DisplayMode displayMode = Dock::DisplayMode::Efficient;
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const int iconSize = displayMode == Dock::Efficient ? 16 : std::min(width(), height()) * 0.8;
 
     QString iconName = "network-";

--- a/plugins/network/item/wirelessitem.cpp
+++ b/plugins/network/item/wirelessitem.cpp
@@ -98,7 +98,7 @@ void WirelessItem::paintEvent(QPaintEvent *e)
 //    const Dock::DisplayMode displayMode = qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>();
     const Dock::DisplayMode displayMode = Dock::DisplayMode::Efficient;
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const int iconSize = displayMode == Dock::Fashion ? std::min(width(), height()) * 0.8 : 16;
     QPixmap pixmap = iconPix(displayMode, iconSize * ratio);
     pixmap.setDevicePixelRatio(ratio);

--- a/plugins/onboard/onboarditem.cpp
+++ b/plugins/onboard/onboarditem.cpp
@@ -56,12 +56,12 @@ void OnboardItem::paintEvent(QPaintEvent *e)
     pixmap = loadSvg(iconName, QSize(iconSize, iconSize));
 
     QPainter painter(this);
-    painter.drawPixmap(rect().center() - pixmap.rect().center() / qApp->devicePixelRatio(), pixmap);
+    painter.drawPixmap(rect().center() - pixmap.rect().center() / devicePixelRatioF(), pixmap);
 }
 
 const QPixmap OnboardItem::loadSvg(const QString &fileName, const QSize &size) const
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
     pixmap = QIcon::fromTheme(fileName).pixmap(size * ratio);

--- a/plugins/overlay-warning/pluginwidget.cpp
+++ b/plugins/overlay-warning/pluginwidget.cpp
@@ -57,12 +57,12 @@ void PluginWidget::paintEvent(QPaintEvent *e)
     pixmap = loadSvg(iconName, QSize(iconSize, iconSize));
 
     QPainter painter(this);
-    painter.drawPixmap(rect().center() - pixmap.rect().center() / qApp->devicePixelRatio(), pixmap);
+    painter.drawPixmap(rect().center() - pixmap.rect().center() / devicePixelRatioF(), pixmap);
 }
 
 const QPixmap PluginWidget::loadSvg(const QString &fileName, const QSize &size) const
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
     pixmap = QIcon::fromTheme(fileName).pixmap(size * ratio);

--- a/plugins/shutdown/pluginwidget.cpp
+++ b/plugins/shutdown/pluginwidget.cpp
@@ -56,12 +56,12 @@ void PluginWidget::paintEvent(QPaintEvent *e)
     pixmap = loadSvg(iconName, QSize(iconSize, iconSize));
 
     QPainter painter(this);
-    painter.drawPixmap(rect().center() - pixmap.rect().center() / qApp->devicePixelRatio(), pixmap);
+    painter.drawPixmap(rect().center() - pixmap.rect().center() / devicePixelRatioF(), pixmap);
 }
 
 const QPixmap PluginWidget::loadSvg(const QString &fileName, const QSize &size) const
 {
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
     pixmap = QIcon::fromTheme(fileName).pixmap(size * ratio);

--- a/plugins/sound/sinkinputwidget.cpp
+++ b/plugins/sound/sinkinputwidget.cpp
@@ -28,9 +28,8 @@
 
 DWIDGET_USE_NAMESPACE
 
-const QPixmap getIconFromTheme(const QString &name, const QSize &size)
+const QPixmap getIconFromTheme(const QString &name, const QSize &size, const qreal ratio)
 {
-    const auto ratio = qApp->devicePixelRatio();
     QPixmap ret = QIcon::fromTheme(name, QIcon::fromTheme("application-x-desktop")).pixmap(size * ratio);
     ret.setDevicePixelRatio(ratio);
 
@@ -47,7 +46,7 @@ SinkInputWidget::SinkInputWidget(const QString &inputPath, QWidget *parent)
 {
     const QString iconName = m_inputInter->icon();
     m_volumeIcon->setAccessibleName("app-" + iconName + "-icon");
-    m_volumeIcon->setPixmap(getIconFromTheme(iconName, QSize(24, 24)));
+    m_volumeIcon->setPixmap(getIconFromTheme(iconName, QSize(24, 24), devicePixelRatioF()));
     m_volumeSlider->setAccessibleName("app-" + iconName + "-slider");
     m_volumeSlider->setMinimum(0);
     m_volumeSlider->setMaximum(1000);
@@ -89,7 +88,7 @@ void SinkInputWidget::setMuteIcon()
     if (m_inputInter->mute()) {
         const auto ratio = devicePixelRatioF();
         QPixmap muteIcon = DHiDPIHelper::loadNxPixmap("://audio-volume-muted-symbolic.svg");
-        QPixmap appIconSource(getIconFromTheme(m_inputInter->icon(), QSize(24, 24)));
+        QPixmap appIconSource(getIconFromTheme(m_inputInter->icon(), QSize(24, 24), devicePixelRatioF()));
 
         QPixmap temp(appIconSource.size());
         temp.fill(Qt::transparent);
@@ -107,7 +106,7 @@ void SinkInputWidget::setMuteIcon()
         appIconSource.setDevicePixelRatio(ratio);
         m_volumeIcon->setPixmap(appIconSource);
     } else {
-        m_volumeIcon->setPixmap(getIconFromTheme(m_inputInter->icon(), QSize(24, 24)));
+        m_volumeIcon->setPixmap(getIconFromTheme(m_inputInter->icon(), QSize(24, 24), devicePixelRatioF()));
     }
 }
 

--- a/plugins/sound/sounditem.cpp
+++ b/plugins/sound/sounditem.cpp
@@ -178,7 +178,7 @@ void SoundItem::refreshIcon()
         iconString = QString("audio-volume-%1-symbolic").arg(volumeString);
     }
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const int iconSize = displayMode == Dock::Fashion ? std::min(width(), height()) * 0.8 : 16;
     const QIcon icon = QIcon::fromTheme(iconString);
     m_iconPixmap = icon.pixmap(iconSize * ratio, iconSize * ratio);

--- a/plugins/trash/trashwidget.cpp
+++ b/plugins/trash/trashwidget.cpp
@@ -170,7 +170,7 @@ void TrashWidget::paintEvent(QPaintEvent *e)
     QWidget::paintEvent(e);
 
     QPainter painter(this);
-    painter.drawPixmap(rect().center() - m_icon.rect().center() / qApp->devicePixelRatio(), m_icon);
+    painter.drawPixmap(rect().center() - m_icon.rect().center() / devicePixelRatioF(), m_icon);
 }
 
 void TrashWidget::resizeEvent(QResizeEvent *e)
@@ -192,8 +192,8 @@ void TrashWidget::updateIcon()
 
     const int size = displayMode == Dock::Fashion ? std::min(width(), height()) * 0.8 : 16;
     QIcon icon = QIcon::fromTheme(iconString);
-    m_icon = icon.pixmap(size * qApp->devicePixelRatio(), size * qApp->devicePixelRatio());
-    m_icon.setDevicePixelRatio(qApp->devicePixelRatio());
+    m_icon = icon.pixmap(size * devicePixelRatioF(), size * devicePixelRatioF());
+    m_icon.setDevicePixelRatio(devicePixelRatioF());
     update();
 }
 

--- a/plugins/tray/snitraywidget.cpp
+++ b/plugins/tray/snitraywidget.cpp
@@ -474,7 +474,7 @@ QPixmap SNITrayWidget::newIconPixmap(IconType iconType)
             break;
     }
 
-    const auto ratio = qApp->devicePixelRatio();
+    const auto ratio = devicePixelRatioF();
     const int iconSizeScaled = IconSize * ratio;
     do {
         // load icon from sni dbus
@@ -521,7 +521,7 @@ QPixmap SNITrayWidget::newIconPixmap(IconType iconType)
         // so, it should be the last fallback
         if (!iconName.isEmpty()) {
             // ThemeAppIcon::getIcon 会处理高分屏缩放问题
-            pixmap = ThemeAppIcon::getIcon(iconName, IconSize);
+            pixmap = ThemeAppIcon::getIcon(iconName, IconSize, devicePixelRatioF());
             if (!pixmap.isNull()) {
                 break;
             }


### PR DESCRIPTION
插入新屏幕后，新屏幕的缩放是1，切换为复制模式后如果继续使用QApplication::devicePixelRatio会导致
显示错误，统一换成QWidget::devicePixelRatio或QScreen::devicePixelRatio。