### PR TITLE
fix: quick click on the preview window will crash

### DIFF
--- a/frame/item/components/appsnapshot.cpp
+++ b/frame/item/components/appsnapshot.cpp
@@ -66,9 +66,6 @@ AppSnapshot::AppSnapshot(const WId wid, QWidget *parent)
     m_closeBtn2D->setVisible(false);
     m_title->setObjectName("AppSnapshotTitle");
 
-    m_waitLeaveTimer->setInterval(200);
-    m_waitLeaveTimer->setSingleShot(true);
-
     QHBoxLayout *centralLayout = new QHBoxLayout;
     centralLayout->addWidget(m_title);
     centralLayout->addWidget(m_closeBtn2D);
@@ -83,9 +80,6 @@ AppSnapshot::AppSnapshot(const WId wid, QWidget *parent)
 
     connect(m_closeBtn2D, &DImageButton::clicked, this, &AppSnapshot::closeWindow, Qt::QueuedConnection);
     connect(m_wmHelper, &DWindowManagerHelper::hasCompositeChanged, this, &AppSnapshot::compositeChanged, Qt::QueuedConnection);
-    connect(m_waitLeaveTimer, &QTimer::timeout, this, [=] {
-        emit entered(wid);
-    });
     QTimer::singleShot(1, this, &AppSnapshot::compositeChanged);
 }
 
@@ -208,7 +202,7 @@ void AppSnapshot::enterEvent(QEvent *e)
         m_closeBtn2D->setVisible(true);
     }
     else {
-        m_waitLeaveTimer->start();
+        emit entered(wid());
     }
 
     update();
@@ -219,7 +213,8 @@ void AppSnapshot::leaveEvent(QEvent *e)
     QWidget::leaveEvent(e);
 
     m_closeBtn2D->setVisible(false);
-    m_waitLeaveTimer->stop();
+
+    emit leaved(wid());
 
     update();
 }

--- a/frame/item/components/appsnapshot.h
+++ b/frame/item/components/appsnapshot.h
@@ -58,6 +58,7 @@ public:
 
 signals:
     void entered(const WId wid) const;
+    void leaved(const WId wid) const;
     void clicked(const WId wid) const;
     void requestCheckWindow() const;
 

--- a/frame/item/components/previewcontainer.h
+++ b/frame/item/components/previewcontainer.h
@@ -72,6 +72,7 @@ private slots:
     void onSnapshotClicked(const WId wid);
     void previewEntered(const WId wid);
     void moveFloatingPreview(const QPoint &p);
+    void previewFloating();
 
 private:
     bool m_needActivate;
@@ -82,6 +83,8 @@ private:
 
     QTimer *m_mouseLeaveTimer;
     DWindowManagerHelper *m_wmHelper;
+    QTimer *m_waitForShowPreviewTimer;
+    WId m_currentWId;
 };
 
 #endif // PREVIEWCONTAINER_H


### PR DESCRIPTION
防止鼠标划过就进预览了，但是点击的时候对象还未赋值，导致空指针崩溃。