### PR TITLE
Battery time left and icon fix

### DIFF
--- a/plugins/power/dbus/dbuspower.cpp
+++ b/plugins/power/dbus/dbuspower.cpp
@@ -24,10 +24,12 @@ DBusPower::DBusPower(QObject *parent)
     qDBusRegisterMetaType<BatteryPercentageMap>();
 
     QDBusConnection::sessionBus().connect(this->service(), this->path(), "org.freedesktop.DBus.Properties",  "PropertiesChanged","sa{sv}as", this, SLOT(__propertyChanged__(QDBusMessage)));
+    QDBusConnection::systemBus().connect("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.DBus.Properties", "PropertiesChanged", this, SLOT(__propertyChanged__(QDBusMessage)));
 }
 
 DBusPower::~DBusPower()
 {
     QDBusConnection::sessionBus().disconnect(service(), path(), "org.freedesktop.DBus.Properties",  "PropertiesChanged",  "sa{sv}as", this, SLOT(propertyChanged(QDBusMessage)));
+    QDBusConnection::systemBus().disconnect("org.freedesktop.UPower", "/org/freedesktop/UPower", "org.freedesktop.DBus.Properties",  "PropertiesChanged", this, SLOT(propertyChanged(QDBusMessage)));
 }
 

--- a/plugins/power/powerplugin.cpp
+++ b/plugins/power/powerplugin.cpp
@@ -102,7 +102,8 @@ QWidget *PowerPlugin::itemTipsWidget(const QString &itemKey)
 
     const uint percentage = qMin(100.0, qMax(0.0, data.value("Display")));
     const QString value = QString("%1%").arg(std::round(percentage));
-    const bool charging = !m_powerInter->onBattery();
+    const int batteryState = m_powerInter->batteryState()["Display"];
+    const bool charging = (batteryState == BatteryState::CHARGING || batteryState == BatteryState::FULLY_CHARGED);
 
     if (!charging) {
         qint64 timeToEmpty = -1;
@@ -115,8 +116,6 @@ QWidget *PowerPlugin::itemTipsWidget(const QString &itemKey)
                 .arg(QDateTime::fromTime_t(timeToEmpty).toUTC().toString("hh:mm:ss"))
         );
     } else {
-        const int batteryState = m_powerInter->batteryState()["Display"];
-
         if (batteryState == BatteryState::FULLY_CHARGED || percentage == 100.)
             m_tipsLabel->setText(tr("Charged %1 Battery Is Charged").arg(value));
         else {

--- a/plugins/power/powerplugin.cpp
+++ b/plugins/power/powerplugin.cpp
@@ -30,10 +30,46 @@ PowerPlugin::PowerPlugin(QObject *parent)
     : QObject(parent),
 
       m_pluginLoaded(false),
-      m_tipsLabel(new TipsWidget)
+      m_tipsLabel(new TipsWidget),
+      m_uPowerInter(new QDBusInterface("org.freedesktop.UPower",
+                                       "/org/freedesktop/UPower",
+                                       "org.freedesktop.UPower",
+                                       QDBusConnection::systemBus())),
+      m_uBatteryDeviceInter(nullptr)
 {
     m_tipsLabel->setVisible(false);
     m_tipsLabel->setObjectName("power");
+
+    if (!m_uPowerInter->isValid()) {
+        qDebug() << "DBusConnection to org.freedesktop.UPower is invalid";
+        return;
+    }
+
+    QDBusReply<QList<QDBusObjectPath>> reply = m_uPowerInter->call("EnumerateDevices");
+    QList<QDBusObjectPath> paths = reply.value();
+    QDBusObjectPath batteryPath;
+
+    foreach(auto objectPath, paths) {
+        qDebug() << "EnumerateDevices: " << objectPath.path();
+
+        if (objectPath.path().contains("battery")) {
+            batteryPath = objectPath;
+            break;
+        }
+    }
+
+    if (batteryPath.path().isEmpty())
+        return;
+    
+    m_uBatteryDeviceInter = new QDBusInterface(
+        "org.freedesktop.UPower",
+        batteryPath.path(),
+        "org.freedesktop.UPower.Device",
+        QDBusConnection::systemBus()
+    );
+    if(!m_uBatteryDeviceInter->isValid()) {
+        qDebug() << QString("DBusConnection to %1 is invalid").arg(batteryPath.path());
+    }
 }
 
 const QString PowerPlugin::pluginName() const
@@ -67,15 +103,32 @@ QWidget *PowerPlugin::itemTipsWidget(const QString &itemKey)
     const uint percentage = qMin(100.0, qMax(0.0, data.value("Display")));
     const QString value = QString("%1%").arg(std::round(percentage));
     const bool charging = !m_powerInter->onBattery();
+
     if (!charging) {
-        m_tipsLabel->setText(tr("Remaining Capacity %1").arg(value));
+        qint64 timeToEmpty = -1;
+        if(m_uBatteryDeviceInter && m_uBatteryDeviceInter->property("TimeToEmpty").isValid())
+            timeToEmpty = m_uBatteryDeviceInter->property("TimeToEmpty").toInt();
+        
+        m_tipsLabel->setText(
+            tr("Remaining Capacity: %1, %2 Until Empty")
+                .arg(value)
+                .arg(QDateTime::fromTime_t(timeToEmpty).toUTC().toString("hh:mm:ss"))
+        );
     } else {
         const int batteryState = m_powerInter->batteryState()["Display"];
 
-        if (batteryState == BATTERY_FULL || percentage == 100.)
-            m_tipsLabel->setText(tr("Charged %1").arg(value));
-        else
-            m_tipsLabel->setText(tr("Charging %1").arg(value));
+        if (batteryState == BatteryState::FULLY_CHARGED || percentage == 100.)
+            m_tipsLabel->setText(tr("Charged %1 Battery Is Charged").arg(value));
+        else {
+            qint64 timeToFull = -1;
+            if(m_uBatteryDeviceInter && m_uBatteryDeviceInter->property("TimeToFull").isValid())
+                timeToFull = m_uBatteryDeviceInter->property("TimeToFull").toInt();
+            m_tipsLabel->setText(
+                tr("Charging %1, %2 Until Full")
+                    .arg(value)
+                    .arg(QDateTime::fromTime_t(timeToFull).toUTC().toString("hh:mm:ss"))
+            );
+        }
     }
 
     return m_tipsLabel;

--- a/plugins/power/powerplugin.h
+++ b/plugins/power/powerplugin.h
@@ -29,8 +29,17 @@
 
 #include <QLabel>
 
-#define BATTERY_DISCHARED   2
-#define BATTERY_FULL        4
+// from https://upower.freedesktop.org/docs/Device.html#Device:State
+enum BatteryState 
+{
+    UNKOWN = 0,
+    CHARGING = 1,
+    DISCHARGING = 2,
+    EMPTY = 3,
+    FULLY_CHARGED = 4,
+    PENDING_CHARGE = 5,
+    PENDING_DISCHARGE = 6
+};
 
 class PowerPlugin : public QObject, PluginsItemInterface
 {
@@ -69,6 +78,8 @@ private:
     TipsWidget *m_tipsLabel;
 
     DBusPower *m_powerInter;
+    QDBusInterface *m_uPowerInter;
+    QDBusInterface *m_uBatteryDeviceInter;
 };
 
 #endif // POWERPLUGIN_H

--- a/plugins/power/powerstatuswidget.cpp
+++ b/plugins/power/powerstatuswidget.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "powerstatuswidget.h"
+#include "powerplugin.h"
 
 #include <QPainter>
 #include <QIcon>
@@ -65,7 +66,8 @@ QPixmap PowerStatusWidget::getBatteryIcon()
     const BatteryPercentageMap data = m_powerInter->batteryPercentage();
     const uint value = qMin(100.0, qMax(0.0, data.value("Display")));
     const int percentage = std::round(value);
-    const bool plugged = !m_powerInter->onBattery();
+    const int batteryState = m_powerInter->batteryState()["Display"];
+    const bool plugged = (batteryState == BatteryState::CHARGING || batteryState == BatteryState::FULLY_CHARGED);
 
     QString percentageStr;
     if (percentage < 10 && percentage >= 0) {


### PR DESCRIPTION
Add remaining time to battery indicator widget tip, solving [issue#46](https://github.com/linuxdeepin/dde-control-center/issues/46) and [issue#96](https://github.com/linuxdeepin/dde-dock/issues/96)

Fix battery icon not updating when charging (tested on my matebook d) fixing https://github.com/linuxdeepin/dde-desktop/issues/39 

More details in commit messages