### PR TITLE
调整dock初始化插件的时间

### DIFF
--- a/frame/util/abstractpluginscontroller.cpp
+++ b/frame/util/abstractpluginscontroller.cpp
@@ -133,7 +133,7 @@ void AbstractPluginsController::startLoader(PluginLoader *loader)
     QGSettings gsetting("com.deepin.dde.dock", "/com/deepin/dde/dock/");
 
     QTimer::singleShot(gsetting.get("delay-plugins-time").toUInt(),
-                       loader, [=] { loader->start(QThread::LowestPriority); });
+                       loader, [=] { loader->start(QThread::NormalPriority); });
 }
 
 void AbstractPluginsController::displayModeChanged()

--- a/frame/util/abstractpluginscontroller.cpp
+++ b/frame/util/abstractpluginscontroller.cpp
@@ -133,7 +133,7 @@ void AbstractPluginsController::startLoader(PluginLoader *loader)
     QGSettings gsetting("com.deepin.dde.dock", "/com/deepin/dde/dock/");
 
     QTimer::singleShot(gsetting.get("delay-plugins-time").toUInt(),
-                       loader, [=] { loader->start(QThread::NormalPriority); });
+                       loader, [=] { loader->start(QThread::LowestPriority); });
 }
 
 void AbstractPluginsController::displayModeChanged()
@@ -205,7 +205,12 @@ void AbstractPluginsController::loadPlugin(const QString &pluginFile)
         return;
     }
 
-    initPlugin(interface);
+    // NOTE(justforlxz): 插件的所有初始化工作都在init函数中进行，
+    // loadPlugin函数是按队列执行的，initPlugin函数会有可能导致
+    // 函数执行被阻塞。
+    QTimer::singleShot(1, this, [=] {
+        initPlugin(interface);
+    });
 }
 
 void AbstractPluginsController::initPlugin(PluginsItemInterface *interface) {

--- a/frame/util/pluginloader.cpp
+++ b/frame/util/pluginloader.cpp
@@ -46,8 +46,6 @@ void PluginLoader::run()
             continue;
 
         emit pluginFounded(pluginsDir.absoluteFilePath(file));
-
-        msleep(500);
     }
 
     emit finished();

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -141,7 +141,7 @@ void MainWindow::launch()
     });
 
     qApp->processEvents();
-    QTimer::singleShot(0, this, &MainWindow::show);
+    QTimer::singleShot(300, this, &MainWindow::show);
 }
 
 bool MainWindow::event(QEvent *e)

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -141,7 +141,7 @@ void MainWindow::launch()
     });
 
     qApp->processEvents();
-    QTimer::singleShot(300, this, &MainWindow::show);
+    QTimer::singleShot(0, this, &MainWindow::show);
 }
 
 bool MainWindow::event(QEvent *e)

--- a/plugins/datetime/datetimeplugin.cpp
+++ b/plugins/datetime/datetimeplugin.cpp
@@ -29,22 +29,8 @@
 #define TIME_FORMAT_KEY "24HourFormat"
 
 DatetimePlugin::DatetimePlugin(QObject *parent)
-    : QObject(parent),
-
-      m_dateTipsLabel(new TipsWidget),
-
-      m_refershTimer(new QTimer(this))
+    : QObject(parent)
 {
-    m_dateTipsLabel->setObjectName("datetime");
-
-    m_refershTimer->setInterval(1000);
-    m_refershTimer->start();
-
-    m_centralWidget = new DatetimeWidget;
-
-    connect(m_centralWidget, &DatetimeWidget::requestUpdateGeometry, [this] { m_proxyInter->itemUpdate(this, pluginName()); });
-
-    connect(m_refershTimer, &QTimer::timeout, this, &DatetimePlugin::updateCurrentTimeString);
 }
 
 const QString DatetimePlugin::pluginName() const
@@ -60,7 +46,6 @@ const QString DatetimePlugin::pluginDisplayName() const
 void DatetimePlugin::init(PluginProxyInterface *proxyInter)
 {
     m_proxyInter = proxyInter;
-    m_centralWidget->set24HourFormat(m_proxyInter->getValue(this, TIME_FORMAT_KEY, true).toBool());
 
     // transfer config
     QSettings settings("deepin", "dde-dock-datetime");
@@ -71,8 +56,34 @@ void DatetimePlugin::init(PluginProxyInterface *proxyInter)
         QFile::remove(settings.fileName());
     }
 
-    if (!pluginIsDisable())
-        m_proxyInter->itemAdded(this, pluginName());
+    if (pluginIsDisable()) {
+        return;
+    }
+
+    m_dateTipsLabel = new TipsWidget;
+    m_refershTimer = new QTimer(this);
+    m_dateTipsLabel->setObjectName("datetime");
+
+    m_refershTimer->setInterval(1000);
+    m_refershTimer->start();
+
+    m_centralWidget = new DatetimeWidget;
+    m_dateTipsLabel = new TipsWidget;
+    m_refershTimer = new QTimer(this);
+    m_dateTipsLabel->setObjectName("datetime");
+
+    m_refershTimer->setInterval(1000);
+    m_refershTimer->start();
+
+    m_centralWidget = new DatetimeWidget;
+
+    connect(m_centralWidget, &DatetimeWidget::requestUpdateGeometry, [this] { m_proxyInter->itemUpdate(this, pluginName()); });
+
+    connect(m_refershTimer, &QTimer::timeout, this, &DatetimePlugin::updateCurrentTimeString);
+    connect(m_centralWidget, &DatetimeWidget::requestUpdateGeometry, [this] { m_proxyInter->itemUpdate(this, pluginName()); });
+
+    connect(m_refershTimer, &QTimer::timeout, this, &DatetimePlugin::updateCurrentTimeString);
+    m_proxyInter->itemAdded(this, pluginName());
 }
 
 void DatetimePlugin::pluginStateSwitched()

--- a/plugins/overlay-warning/overlay-warning-plugin.h
+++ b/plugins/overlay-warning/overlay-warning-plugin.h
@@ -20,8 +20,8 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-#ifndef SHUTDOWNPLUGIN_H
-#define SHUTDOWNPLUGIN_H
+#ifndef OVERLAY_WARNING_PLUGIN_H
+#define OVERLAY_WARNING_PLUGIN_H
 
 #include "pluginsiteminterface.h"
 #include "pluginwidget.h"
@@ -75,4 +75,4 @@ private:
     QTimer *m_showDisableOverlayDialogTimer;
 };
 
-#endif // SHUTDOWNPLUGIN_H
+#endif // OVERLAY_WARNING_PLUGIN_H

--- a/plugins/tray/trayplugin.cpp
+++ b/plugins/tray/trayplugin.cpp
@@ -50,10 +50,10 @@ TrayPlugin::TrayPlugin(QObject *parent)
       m_refreshSNIItemsTimer(new QTimer(this)),
       m_tipsLabel(new TipsWidget)
 {
-    m_refreshXEmbedItemsTimer->setInterval(500);
+    m_refreshXEmbedItemsTimer->setInterval(0);
     m_refreshXEmbedItemsTimer->setSingleShot(true);
 
-    m_refreshSNIItemsTimer->setInterval(500);
+    m_refreshSNIItemsTimer->setInterval(0);
     m_refreshSNIItemsTimer->setSingleShot(true);
 
     m_tipsLabel->setObjectName("tray");
@@ -92,9 +92,8 @@ void TrayPlugin::init(PluginProxyInterface *proxyInter)
 
     QTimer::singleShot(0, this, &TrayPlugin::loadIndicator);
     QTimer::singleShot(0, m_systemTraysController, &SystemTraysController::startLoader);
-
-    QTimer::singleShot(3000, this, &TrayPlugin::initSNI);
-    QTimer::singleShot(4000, this, &TrayPlugin::initXEmbed);
+    QTimer::singleShot(0, this, &TrayPlugin::initSNI);
+    QTimer::singleShot(0, this, &TrayPlugin::initXEmbed);
 }
 
 bool TrayPlugin::pluginIsDisable()

--- a/plugins/tray/trayplugin.cpp
+++ b/plugins/tray/trayplugin.cpp
@@ -41,24 +41,8 @@
 using org::kde::StatusNotifierWatcher;
 
 TrayPlugin::TrayPlugin(QObject *parent)
-    : QObject(parent),
-      m_trayInter(new DBusTrayManager(this)),
-      m_sniWatcher(new StatusNotifierWatcher(SNI_WATCHER_SERVICE, SNI_WATCHER_PATH, QDBusConnection::sessionBus(), this)),
-      m_fashionItem (new FashionTrayItem(this)),
-      m_systemTraysController(new SystemTraysController(this)),
-      m_refreshXEmbedItemsTimer(new QTimer(this)),
-      m_refreshSNIItemsTimer(new QTimer(this)),
-      m_tipsLabel(new TipsWidget)
+    : QObject(parent)
 {
-    m_refreshXEmbedItemsTimer->setInterval(0);
-    m_refreshXEmbedItemsTimer->setSingleShot(true);
-
-    m_refreshSNIItemsTimer->setInterval(0);
-    m_refreshSNIItemsTimer->setSingleShot(true);
-
-    m_tipsLabel->setObjectName("tray");
-    m_tipsLabel->setText(tr("System Tray"));
-    m_tipsLabel->setVisible(false);
 }
 
 const QString TrayPlugin::pluginName() const
@@ -83,8 +67,26 @@ void TrayPlugin::init(PluginProxyInterface *proxyInter)
         return;
     }
 
+    m_trayInter = new DBusTrayManager(this);
+    m_sniWatcher = new StatusNotifierWatcher(SNI_WATCHER_SERVICE, SNI_WATCHER_PATH, QDBusConnection::sessionBus(), this);
+    m_fashionItem = new FashionTrayItem(this);
+    m_systemTraysController = new SystemTraysController(this);
+    m_refreshXEmbedItemsTimer = new QTimer(this);
+    m_refreshSNIItemsTimer = new QTimer(this);
+    m_tipsLabel = new TipsWidget;
+
+    m_refreshXEmbedItemsTimer->setInterval(0);
+    m_refreshXEmbedItemsTimer->setSingleShot(true);
+
+    m_refreshSNIItemsTimer->setInterval(0);
+    m_refreshSNIItemsTimer->setSingleShot(true);
+
+    m_tipsLabel->setObjectName("tray");
+    m_tipsLabel->setText(tr("System Tray"));
+    m_tipsLabel->setVisible(false);
+
     connect(m_systemTraysController, &SystemTraysController::pluginItemAdded, this, &TrayPlugin::addTrayWidget);
-    connect(m_systemTraysController, &SystemTraysController::pluginItemRemoved, this, [=](const QString &itemKey) {trayRemoved(itemKey);});
+    connect(m_systemTraysController, &SystemTraysController::pluginItemRemoved, this, [=](const QString &itemKey) { trayRemoved(itemKey); });
 
     m_trayInter->Manage();
 


### PR DESCRIPTION
删除影响的延时器和调整部分构造函数，使其可以快速的完成插件的加载，插件的初始化函数将在其他线程被执行。