### PR TITLE
fix: crash at AppDragWidget

### DIFF
--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -475,6 +475,7 @@ void AppItem::startDrag()
     // handle drag finished here
     connect(m_drag->appDragWidget(), &AppDragWidget::destroyed, this, [=] {
         m_dragging = false;
+        m_drag.clear();
         setVisible(true);
         update();
     });


### PR DESCRIPTION
mark m_drag to nullptr when the app drag widget destroyed

当drag对应的控件销毁时，应当将 m_drag 置为空