### PR TITLE
fix: Datetime 24 format at plugin initialization

### DIFF
--- a/plugins/datetime/datetimeplugin.cpp
+++ b/plugins/datetime/datetimeplugin.cpp
@@ -84,6 +84,7 @@ void DatetimePlugin::init(PluginProxyInterface *proxyInter)
 
     connect(m_refershTimer, &QTimer::timeout, this, &DatetimePlugin::updateCurrentTimeString);
     m_proxyInter->itemAdded(this, pluginName());
+    m_centralWidget->set24HourFormat(m_proxyInter->getValue(this, TIME_FORMAT_KEY, true).toBool());
 }
 
 void DatetimePlugin::pluginStateSwitched()


### PR DESCRIPTION
This fix refers to issue https://github.com/linuxdeepin/developer-center/issues/1444. There is already another pull request https://github.com/linuxdeepin/dde-dock/pull/248 that changes much more code. My changes are minimal and fulfill the task as well.