### PR TITLE
Update trashplugin.cpp

### DIFF
--- a/plugins/trash/trashplugin.cpp
+++ b/plugins/trash/trashplugin.cpp
@@ -88,7 +88,7 @@ QWidget *TrashPlugin::itemTipsWidget(const QString &itemKey)
     Q_UNUSED(itemKey);
 
     const int count = m_trashWidget->trashItemCount();
-    if (count < 2)
+    if (count == 1)
         m_tipsLabel->setText(tr("Trash - %1 file").arg(count));
     else
         m_tipsLabel->setText(tr("Trash - %1 files").arg(count));
@@ -189,4 +189,3 @@ void TrashPlugin::refreshPluginItemsVisible()
         m_proxyInter->itemAdded(this, pluginName());
     }
 }
-


### PR DESCRIPTION
fixed translation error where the plugin displays **0 file** in trash instead of **0 files** .
I changed this by changing the if cause for the text display to `if (count == 1)` instead of the original `if (count < 2)`