### PR TITLE
fix: Fix dode-dock incorrectly set to right angle

### DIFF
--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -338,7 +338,7 @@ void MainWindow::adjustShadowMask()
 
     if (Dtk::Core::DSysInfo::isCommunityEdition()) {
         auto theme = DGuiApplicationHelper::instance()->systemTheme();
-        radius = theme->windowRadius();
+        radius = theme->windowRadius(radius);
     }
 
     int newRadius = composite && isFasion ? radius : 0;


### PR DESCRIPTION
Fix dede-dock set to right angle after every logout or reboot

Log: