### PR TITLE
feat: Initial packit setup

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,0 +1,19 @@
+# See the documentation for more information:
+# https://packit.dev/docs/configuration/
+
+specfile_path: rpm/deepin-dock.spec
+
+# add or remove files that should be synced
+synced_files:
+    - rpm/deepin-dock.spec
+    - .packit.yaml
+
+upstream_package_name: dde-dock
+# downstream (Fedora) RPM package name
+downstream_package_name: deepin-dock
+
+actions:
+  fix-spec-file: |
+    bash -c "sed -i -r \"0,/Version:/ s/Version:(\s*)\S*/Version:\1${PACKIT_PROJECT_VERSION}/\" rpm/deepin-dock.spec"
+  post-upstream-clone: |
+    cp rpm/dde-dock.spec rpm/deepin-dock.spec


### PR DESCRIPTION
This commit contains the specfile for building the official package for Fedora
with a Packit setup.

Ultimately, a unified specfile is targeted for Fedora and any other rpm-based
distributions, e.g. openEuler.

And Packit(https://packit.dev/) is a tool for maintaining specfile within
upstream source. It requires a simple config file(.packit.yaml).

Log: Initial packit setup
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>