### PR TITLE
feat: support window list on menu context

### DIFF
--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -40,8 +40,11 @@
 #include <QX11Info>
 #include <QGSettings>
 #include <DGuiApplicationHelper>
+#include <DSysInfo>
 
 #define APP_DRAG_THRESHOLD      20
+
+DCORE_USE_NAMESPACE
 
 QPoint AppItem::MousePressPos;
 
@@ -473,9 +476,38 @@ void AppItem::invokedMenuItem(const QString &itemId, const bool checked)
     m_itemEntryInter->HandleMenuItem(QX11Info::getTimestamp(), itemId);
 }
 
+void AppItem::invokedMenuItem(const QString &group, const QString &itemId, const bool checked)
+{
+    if (group == "windows") {
+        m_itemEntryInter->Activate(itemId.toUInt());
+        return;
+    }
+
+    return invokedMenuItem(itemId, checked);
+}
+
 const QString AppItem::contextMenu() const
 {
-    return m_itemEntryInter->menu();
+    // NOTE(lxz): If there are already open windows, add a new menu.
+    // itemid needs to be a negative number
+    // because itemid needs to be passed to the backend
+    if (m_windowInfos.isEmpty() || !DSysInfo::isCommunityEdition()) {
+        return m_itemEntryInter->menu();
+    }
+
+    QJsonObject obj = QJsonDocument::fromJson(m_itemEntryInter->menu().toUtf8()).object();
+    QJsonArray windows;
+
+    for (auto it = m_windowInfos.cbegin(); it != m_windowInfos.cend(); ++it) {
+        windows << QJsonObject{
+            {"winid", QString::number(it.key())},
+            {"title", it.value().title}
+        };
+    }
+
+    obj["windows"] = windows;
+
+    return QJsonDocument(obj).toJson(QJsonDocument::Compact);
 }
 
 QWidget *AppItem::popupTips()

--- a/frame/item/appitem.h
+++ b/frame/item/appitem.h
@@ -81,6 +81,7 @@ private:
 
     void showHoverTips() override;
     void invokedMenuItem(const QString &itemId, const bool checked) override;
+    void invokedMenuItem(const QString &group, const QString &itemId, const bool checked) override;
     const QString contextMenu() const override;
     QWidget *popupTips() override;
     void startDrag();

--- a/frame/item/dockitem.cpp
+++ b/frame/item/dockitem.cpp
@@ -241,6 +241,18 @@ void DockItem::showContextMenu()
 
     qDeleteAll(m_contextMenu.actions());
 
+    QJsonArray windows = jsonMenu["windows"].toArray();
+    for (const auto &item : windows) {
+        QJsonObject itemObj = item.toObject();
+        QAction *action = new QAction(itemObj.value("title").toString());
+        action->setData(itemObj["winid"].toString());
+        action->setProperty("__APP_WINDOWS__", true);
+        action->setProperty("__APP_MENU_GROUP__", "windows");
+        m_contextMenu.addAction(action);
+    }
+
+    m_contextMenu.addSeparator();
+
     QJsonArray jsonMenuItems = jsonMenu.value("items").toArray();
     for (auto item : jsonMenuItems) {
         QJsonObject itemObj = item.toObject();
@@ -262,6 +274,10 @@ void DockItem::showContextMenu()
 
 void DockItem::menuActionClicked(QAction *action)
 {
+    if (action->property("__APP_WINDOWS__").toBool()) {
+        return invokedMenuItem(action->property("__APP_MENU_GROUP__").toString(), action->data().toString(), true);
+    }
+
     invokedMenuItem(action->data().toString(), true);
 }
 
@@ -342,6 +358,13 @@ void DockItem::showPopupApplet(QWidget *const applet)
 
 void DockItem::invokedMenuItem(const QString &itemId, const bool checked)
 {
+    Q_UNUSED(itemId)
+    Q_UNUSED(checked)
+}
+
+void DockItem::invokedMenuItem(const QString &group, const QString &itemId, const bool checked)
+{
+    Q_UNUSED(group)
     Q_UNUSED(itemId)
     Q_UNUSED(checked)
 }

--- a/frame/item/dockitem.h
+++ b/frame/item/dockitem.h
@@ -91,6 +91,7 @@ protected:
     virtual void showPopupWindow(QWidget *const content, const bool model = false);
     virtual void showHoverTips();
     virtual void invokedMenuItem(const QString &itemId, const bool checked);
+    virtual void invokedMenuItem(const QString &group, const QString &itemId, const bool checked);
     virtual const QString contextMenu() const;
     virtual QWidget *popupTips();
 


### PR DESCRIPTION
Adding a window list to the menu will help users to switch windows conveniently.

Log: support window list on menu context
Issue: Closes #344