### PR TITLE
fix: rpm BuildRequires make

### DIFF
--- a/rpm/dde-dock.spec
+++ b/rpm/dde-dock.spec
@@ -47,6 +47,7 @@ BuildRequires:  gtest-devel
 Requires:       dbusmenu-qt5
 %if 0%{?fedora}
 BuildRequires:  qt5-qtbase-private-devel
+BuildRequires:  make
 Requires:       deepin-network-utils
 Requires:       deepin-qt-dbus-factory
 %else


### PR DESCRIPTION
Fedora no longer installs make in the default build environment.

Log:
Signed-off-by: Robin Lee <cheeselee@fedoraproject.org>