### PR TITLE
Link some libraries to fix build on openSUSE

### DIFF
--- a/plugins/bluetooth/CMakeLists.txt
+++ b/plugins/bluetooth/CMakeLists.txt
@@ -32,6 +32,7 @@ target_include_directories(${PLUGIN_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS}
 target_link_libraries(${PLUGIN_NAME} PRIVATE
   ${XCB_EWMH_LIBRARIES}
   ${DtkWidget_LIBRARIES}
+  ${XCB_EWMH_LIBRARIES}
   ${DFrameworkDBus_LIBRARIES}
   ${QGSettings_LIBRARIES}
   ${Qt5DBus_LIBRARIES}


### PR DESCRIPTION
Fix build on openSUSE ( https://github.com/linuxdeepin/developer-center/issues/2244 ). Some library links are necessary.