### PR TITLE
fix: 修复插件sizePolicy无效的问题

### DIFF
--- a/frame/window/mainpanelcontrol.cpp
+++ b/frame/window/mainpanelcontrol.cpp
@@ -1151,14 +1151,14 @@ void MainPanelControl::calcuDockIconSize(int w, int h, int traySize)
     m_appAreaSonLayout->setContentsMargins(appLeftAndRightMargin, appTopAndBottomMargin, appLeftAndRightMargin, appTopAndBottomMargin);
     m_trayAreaLayout->setContentsMargins(trayLeftAndRightMargin, trayTopAndBottomMargin, trayLeftAndRightMargin, trayTopAndBottomMargin);
 
-    //因为日期时间插件大小和其他插件大小有异，需要单独设置各插件的边距
-    //而不对日期时间插件设置边距
+    //因为日期时间插件或第三方插件声明自定义大小
+    //而不对自定义大小插件设置边距
     for (int i = 0; i < m_pluginLayout->count(); ++ i) {
         QLayout *layout = m_pluginLayout->itemAt(i)->layout();
         if (layout && layout->itemAt(0)) {
             PluginsItem *pItem = static_cast<PluginsItem *>(layout->itemAt(0)->widget());
 
-            if (pItem && pItem->pluginName() != "datetime") {
+            if (pItem && pItem->pluginSizePolicy() != PluginsItemInterface::Custom) {
                 layout->setContentsMargins(trayLeftAndRightMargin, trayTopAndBottomMargin, trayLeftAndRightMargin, trayTopAndBottomMargin);
             }
         }


### PR DESCRIPTION
第三方插件设置了sizePolicy，但是仍然被遮挡，这是因为dock中未对插件的sizePolicy作出判断，当前已修改

Log: 修复第三方插件sizePolicy无效问题
Influence: 第三方插件宽高