### PR TITLE
fix: missing deepin-control-center-git

### DIFF
--- a/archlinux/PKGBUILD
+++ b/archlinux/PKGBUILD
@@ -8,7 +8,10 @@ url="https://github.com/linuxdeepin/dde-dock"
 license=('GPL3')
 depends=('qt5-svg' 'deepin-daemon-git' 'deepin-qt5integration-git'
          'deepin-qt-dbus-factory-git' 'deepin-network-utils-git' 'libdbusmenu-qt5')
-makedepends=('git' 'cmake' 'ninja' 'qt5-tools' 'gtest' 'gmock' 'dtkcommon-git' 'dtkcore-git' 'deepin-qt5integration-git' 'deepin-qt-dbus-factory' 'deepin-network-utils-git' 'libdbusmenu-qt5')
+makedepends=('git' 'cmake' 'ninja' 'qt5-tools' 'gtest' 'gmock' 
+             'dtkcommon-git' 'dtkcore-git' 'deepin-qt5integration-git'
+             'deepin-qt-dbus-factory' 'deepin-network-utils-git' 'libdbusmenu-qt5'
+             'deepin-control-center-git')
 conflicts=('deepin-dock')
 provides=('deepin-dock')
 groups=('deepin-git')


### PR DESCRIPTION
add deepin-control-center-git to build dep

Log: