### PR TITLE
test topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,3 +19,4 @@ We encourage you to report issues and contribute changes
 
 * [Contribution guide for developers](https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers-en). (English)
 * [开发者代码贡献指南](https://github.com/linuxdeepin/developer-center/wiki/Contribution-Guidelines-for-Developers) (中文)
+

--- a/frame/window/mainpanelcontrol.cpp
+++ b/frame/window/mainpanelcontrol.cpp
@@ -664,7 +664,7 @@ bool MainPanelControl::eventFilter(QObject *watched, QEvent *event)
             moveAppSonWidget();
     }
 
-    if (Utils::IS_WAYLAND_DISPLAY && m_appDragWidget && watched == static_cast<QGraphicsView *>(m_appDragWidget)->viewport()) {
+    if (!Utils::IS_WAYLAND_DISPLAY && m_appDragWidget && watched == static_cast<QGraphicsView *>(m_appDragWidget)->viewport()) {
         bool isContains = rect().contains(mapFromGlobal(QCursor::pos()));
         if (isContains) {
             if (event->type() == QEvent::DragMove) {

--- a/plugins/tray/abstracttraywidget.cpp
+++ b/plugins/tray/abstracttraywidget.cpp
@@ -137,3 +137,8 @@ uint AbstractTrayWidget::getOwnerPID()
 {
     return this->m_ownerPID;
 }
+
+void AbstractTrayWidget::setOwnerPID(uint PID)
+{
+    this->m_ownerPID = PID;
+}

--- a/plugins/tray/abstracttraywidget.cpp
+++ b/plugins/tray/abstracttraywidget.cpp
@@ -132,3 +132,8 @@ void AbstractTrayWidget::resizeEvent(QResizeEvent *event)
         setMaximumWidth(QWIDGETSIZE_MAX);
     }
 }
+
+uint AbstractTrayWidget::getOwnerPID()
+{
+    return this->m_ownerPID;
+}

--- a/plugins/tray/abstracttraywidget.h
+++ b/plugins/tray/abstracttraywidget.h
@@ -43,6 +43,7 @@ public:
     virtual void sendClick(uint8_t mouseButton, int x, int y) = 0;
     virtual inline TrayType trayTyep() const { return TrayType::ApplicationTray; } // default is ApplicationTray
     virtual bool isValid() {return true;}
+    uint getOwnerPID();
 
 Q_SIGNALS:
     void iconChanged();
@@ -58,6 +59,8 @@ protected:
     void handleMouseRelease();
     const QRect perfectIconRect() const;
     void resizeEvent(QResizeEvent *event) override;
+
+    uint m_ownerPID;
 
 private:
     QTimer *m_handleMouseReleaseTimer;

--- a/plugins/tray/abstracttraywidget.h
+++ b/plugins/tray/abstracttraywidget.h
@@ -59,12 +59,13 @@ protected:
     void handleMouseRelease();
     const QRect perfectIconRect() const;
     void resizeEvent(QResizeEvent *event) override;
-
-    uint m_ownerPID;
+    void setOwnerPID(uint PID);
 
 private:
     QTimer *m_handleMouseReleaseTimer;
 
     QPair<QPoint, Qt::MouseButton> m_lastMouseReleaseData;
+
+    uint m_ownerPID;
 };
 

--- a/plugins/tray/abstracttraywidget.h
+++ b/plugins/tray/abstracttraywidget.h
@@ -66,6 +66,6 @@ private:
 
     QPair<QPoint, Qt::MouseButton> m_lastMouseReleaseData;
 
-    uint m_ownerPID;
+    uint m_ownerPID = 0;
 };
 

--- a/plugins/tray/snitraywidget.cpp
+++ b/plugins/tray/snitraywidget.cpp
@@ -81,7 +81,7 @@ SNITrayWidget::SNITrayWidget(const QString &sniServicePath, QWidget *parent)
     m_dbusPath = pair.second;
 
     QDBusConnection conn = QDBusConnection::sessionBus();
-    m_ownerPID = conn.interface()->servicePid(m_dbusService);
+    setOwnerPID(conn.interface()->servicePid(m_dbusService));
 
     m_sniInter = new StatusNotifierItem(m_dbusService, m_dbusPath, QDBusConnection::sessionBus(), this);
     m_sniInter->setSync(false);
@@ -245,6 +245,11 @@ QPair<QString, QString> SNITrayWidget::serviceAndPath(const QString &servicePath
     }
 
     return pair;
+}
+
+QString SNITrayWidget::serviceName(const QString &servicePath)
+{
+    return serviceAndPath(servicePath).first;
 }
 
 void SNITrayWidget::initSNIPropertys()

--- a/plugins/tray/snitraywidget.cpp
+++ b/plugins/tray/snitraywidget.cpp
@@ -247,9 +247,11 @@ QPair<QString, QString> SNITrayWidget::serviceAndPath(const QString &servicePath
     return pair;
 }
 
-QString SNITrayWidget::serviceName(const QString &servicePath)
+uint SNITrayWidget::servicePID(const QString &servicePath)
 {
-    return serviceAndPath(servicePath).first;
+    QString serviceName = serviceAndPath(servicePath).first;
+    QDBusConnection conn = QDBusConnection::sessionBus();
+    return conn.interface()->servicePid(serviceName);
 }
 
 void SNITrayWidget::initSNIPropertys()

--- a/plugins/tray/snitraywidget.cpp
+++ b/plugins/tray/snitraywidget.cpp
@@ -80,6 +80,9 @@ SNITrayWidget::SNITrayWidget(const QString &sniServicePath, QWidget *parent)
     m_dbusService = pair.first;
     m_dbusPath = pair.second;
 
+    QDBusConnection conn = QDBusConnection::sessionBus();
+    m_ownerPID = conn.interface()->servicePid(m_dbusService);
+
     m_sniInter = new StatusNotifierItem(m_dbusService, m_dbusPath, QDBusConnection::sessionBus(), this);
     m_sniInter->setSync(false);
 

--- a/plugins/tray/snitraywidget.h
+++ b/plugins/tray/snitraywidget.h
@@ -66,7 +66,7 @@ public:
     static QString toSNIKey(const QString &sniServicePath);
     static bool isSNIKey(const QString &itemKey);
     static QPair<QString, QString> serviceAndPath(const QString &servicePath);
-    static QString serviceName(const QString &servicePath);
+    static uint servicePID(const QString &servicePath);
 
     void showHoverTips();
     const QPoint topleftPoint() const;

--- a/plugins/tray/snitraywidget.h
+++ b/plugins/tray/snitraywidget.h
@@ -66,6 +66,7 @@ public:
     static QString toSNIKey(const QString &sniServicePath);
     static bool isSNIKey(const QString &itemKey);
     static QPair<QString, QString> serviceAndPath(const QString &servicePath);
+    static QString serviceName(const QString &servicePath);
 
     void showHoverTips();
     const QPoint topleftPoint() const;

--- a/plugins/tray/trayplugin.cpp
+++ b/plugins/tray/trayplugin.cpp
@@ -344,7 +344,11 @@ void TrayPlugin::sniItemsChanged()
         }
     }
 
+    m_registerSNIPID.clear();
+    QDBusConnection conn = QDBusConnection::connectToBus(QDBusConnection::SessionBus, "org.freedesktop.DBus");
     for (int i = 0; i < sinTrayKeyList.size(); ++i) {
+        QString dbusName = SNITrayWidget::serviceAndPath(itemServicePaths.at(i)).first;
+        m_registerSNIPID.insert(conn.interface()->servicePid(dbusName));
         traySNIAdded(sinTrayKeyList.at(i), itemServicePaths.at(i));
     }
 }
@@ -353,8 +357,15 @@ void TrayPlugin::xembedItemsChanged()
 {
     QList<quint32> winidList = m_trayInter->trayIcons();
     QStringList trayKeyList;
+    QList<quint32> xembedOnlyWinIdList;
 
     for (auto winid : winidList) {
+        if (!m_registerSNIPID.contains(XEmbedTrayWidget::getWindowPID(winid))) {
+            xembedOnlyWinIdList.append(winid);
+        }
+    }
+
+    for (auto winid : xembedOnlyWinIdList) {
         trayKeyList << XEmbedTrayWidget::toXEmbedKey(winid);
     }
 
@@ -365,7 +376,7 @@ void TrayPlugin::xembedItemsChanged()
     }
 
     for (int i = 0; i < trayKeyList.size(); ++i) {
-        trayXEmbedAdded(trayKeyList.at(i), winidList.at(i));
+        trayXEmbedAdded(trayKeyList.at(i), xembedOnlyWinIdList.at(i));
     }
 }
 

--- a/plugins/tray/trayplugin.cpp
+++ b/plugins/tray/trayplugin.cpp
@@ -346,8 +346,8 @@ void TrayPlugin::sniItemsChanged()
     }
     QDBusConnection conn = QDBusConnection::sessionBus();
     for (int i = 0; i < sinTrayKeyList.size(); ++i) {
-        QString dbusName = SNITrayWidget::serviceName(itemServicePaths.at(i));
-        uint pid = conn.interface()->servicePid(dbusName);
+        uint pid = SNITrayWidget::servicePID(itemServicePaths.at(i));
+        // uint pid = conn.interface()->servicePid(dbusName);
 
         if (!m_registertedPID.contains(pid)) {
             traySNIAdded(sinTrayKeyList.at(i), itemServicePaths.at(i));

--- a/plugins/tray/trayplugin.cpp
+++ b/plugins/tray/trayplugin.cpp
@@ -327,7 +327,6 @@ void TrayPlugin::initSNI()
 void TrayPlugin::sniItemsChanged()
 {
     const QStringList &itemServicePaths = m_sniWatcher->registeredStatusNotifierItems();
-    QDBusConnection conn = QDBusConnection::sessionBus();
     QStringList sinTrayKeyList;
 
     for (auto item : itemServicePaths) {
@@ -335,7 +334,7 @@ void TrayPlugin::sniItemsChanged()
     }
     for (auto itemKey : m_trayMap.keys()) {
         if (!sinTrayKeyList.contains(itemKey) && SNITrayWidget::isSNIKey(itemKey)) {
-            m_registedPID.remove(m_trayMap[itemKey]->getOwnerPID());
+            m_registertedPID.remove(m_trayMap[itemKey]->getOwnerPID());
             trayRemoved(itemKey);
         }
     }
@@ -345,13 +344,14 @@ void TrayPlugin::sniItemsChanged()
             m_passiveSNITrayMap.take(itemKey)->deleteLater();
         }
     }
+    QDBusConnection conn = QDBusConnection::sessionBus();
     for (int i = 0; i < sinTrayKeyList.size(); ++i) {
-        QString dbusName = SNITrayWidget::serviceAndPath(itemServicePaths.at(i)).first;
+        QString dbusName = SNITrayWidget::serviceName(itemServicePaths.at(i));
         uint pid = conn.interface()->servicePid(dbusName);
 
-        if (!m_registedPID.contains(pid)) {
+        if (!m_registertedPID.contains(pid)) {
             traySNIAdded(sinTrayKeyList.at(i), itemServicePaths.at(i));
-            m_registedPID.insert(pid);
+            m_registertedPID.insert(pid);
         }
     }
 }
@@ -361,28 +361,28 @@ void TrayPlugin::xembedItemsChanged()
     QList<quint32> winidList = m_trayInter->trayIcons();
     QStringList newlyAddedTrayKeyList;
     QStringList allKeytary;
-    QList<quint32> newlyAdded;
+    QList<quint32> newlyAddedWindowID;
 
     for (auto winid : winidList) {
         uint pid = XEmbedTrayWidget::getWindowPID(winid);
         allKeytary << XEmbedTrayWidget::toXEmbedKey(winid);
 
-        if (!m_registedPID.contains(pid)) {
-            m_registedPID.insert(pid);
-            newlyAdded << winid;
+        if (!m_registertedPID.contains(pid)) {
+            m_registertedPID.insert(pid);
+            newlyAddedWindowID << winid;
             newlyAddedTrayKeyList << XEmbedTrayWidget::toXEmbedKey(winid);
         }
     }
 
     for (auto tray : m_trayMap.keys()) {
         if (!allKeytary.contains(tray) && XEmbedTrayWidget::isXEmbedKey(tray)) {
-            m_registedPID.remove(m_trayMap[tray]->getOwnerPID());
+            m_registertedPID.remove(m_trayMap[tray]->getOwnerPID());
             trayRemoved(tray);
         }
     }
 
     for (int i = 0; i < newlyAddedTrayKeyList.size(); ++i) {
-        trayXEmbedAdded(newlyAddedTrayKeyList.at(i), newlyAdded.at(i));
+        trayXEmbedAdded(newlyAddedTrayKeyList.at(i), newlyAddedWindowID.at(i));
     }
 }
 

--- a/plugins/tray/trayplugin.h
+++ b/plugins/tray/trayplugin.h
@@ -105,7 +105,7 @@ private:
     QMap<QString, AbstractTrayWidget *> m_trayMap;
     QMap<QString, SNITrayWidget *> m_passiveSNITrayMap;     //这个目前好像无用了
     QMap<QString, IndicatorTray*> m_indicatorMap;           //这个有键盘跟license
-    QSet<uint> m_registedPID;
+    QSet<uint> m_registertedPID;
 
     bool m_pluginLoaded;
     std::mutex m_sniMutex;

--- a/plugins/tray/trayplugin.h
+++ b/plugins/tray/trayplugin.h
@@ -105,7 +105,7 @@ private:
     QMap<QString, AbstractTrayWidget *> m_trayMap;
     QMap<QString, SNITrayWidget *> m_passiveSNITrayMap;     //这个目前好像无用了
     QMap<QString, IndicatorTray*> m_indicatorMap;           //这个有键盘跟license
-    QSet<long> m_registerSNIPID;
+    QSet<uint> m_registedPID;
 
     bool m_pluginLoaded;
     std::mutex m_sniMutex;

--- a/plugins/tray/trayplugin.h
+++ b/plugins/tray/trayplugin.h
@@ -105,6 +105,7 @@ private:
     QMap<QString, AbstractTrayWidget *> m_trayMap;
     QMap<QString, SNITrayWidget *> m_passiveSNITrayMap;     //这个目前好像无用了
     QMap<QString, IndicatorTray*> m_indicatorMap;           //这个有键盘跟license
+    QSet<long> m_registerSNIPID;
 
     bool m_pluginLoaded;
     std::mutex m_sniMutex;

--- a/plugins/tray/xembedtraywidget.cpp
+++ b/plugins/tray/xembedtraywidget.cpp
@@ -574,3 +574,31 @@ bool XEmbedTrayWidget::isBadWindow()
 
     return result;
 }
+
+long XEmbedTrayWidget::getWindowPID(uint winId)
+{
+    long pid = -1;
+    const auto display = IS_WAYLAND_DISPLAY ? XOpenDisplay(nullptr) : QX11Info::display();
+    if (!display) {
+        qWarning() << "QX11Info::connection() is " << display;
+        return pid;
+    }
+
+    Atom nameAtom = XInternAtom(display, "_NET_WM_PID", 1);
+    Atom type;
+    int format, status;
+
+    unsigned long nitems, after;
+    unsigned char *data;
+
+    status = XGetWindowProperty(display, winId, nameAtom, 0, 1024, 0,
+            XInternAtom(display, "CARDINAL", 0), &type, &format, &nitems, &after, &data);
+    if (status == Success && data) {
+        pid = *((long*)data);
+        XFree(data);
+        qDebug() << "_NET_WM_PID = " << pid;
+    }
+    else
+        qDebug() << "_NET_WM_PID not found";
+    return pid;
+}

--- a/plugins/tray/xembedtraywidget.cpp
+++ b/plugins/tray/xembedtraywidget.cpp
@@ -90,7 +90,7 @@ XEmbedTrayWidget::XEmbedTrayWidget(quint32 winId, xcb_connection_t *cnn, Display
 {
     wrapWindow();
 
-    m_ownerPID = getWindowPID(winId);
+    setOwnerPID(getWindowPID(winId));
 
     m_updateTimer = new QTimer(this);
     m_updateTimer->setInterval(100);

--- a/plugins/tray/xembedtraywidget.h
+++ b/plugins/tray/xembedtraywidget.h
@@ -45,6 +45,7 @@ public:
 
     static QString getWindowProperty(quint32 winId, QString propName);
     static QString toXEmbedKey(quint32 winId);
+    static long getWindowPID(quint32 winId);
     static bool isXEmbedKey(const QString &itemKey);
     virtual bool isValid() override {return m_valid;}
 

--- a/plugins/tray/xembedtraywidget.h
+++ b/plugins/tray/xembedtraywidget.h
@@ -45,7 +45,6 @@ public:
 
     static QString getWindowProperty(quint32 winId, QString propName);
     static QString toXEmbedKey(quint32 winId);
-    static quint32 getWinidFromXEmbedKey(const QString &itemkey);
     static uint getWindowPID(quint32 winId);
     static bool isXEmbedKey(const QString &itemKey);
     virtual bool isValid() override {return m_valid;}

--- a/plugins/tray/xembedtraywidget.h
+++ b/plugins/tray/xembedtraywidget.h
@@ -45,7 +45,8 @@ public:
 
     static QString getWindowProperty(quint32 winId, QString propName);
     static QString toXEmbedKey(quint32 winId);
-    static long getWindowPID(quint32 winId);
+    static quint32 getWinidFromXEmbedKey(const QString &itemkey);
+    static uint getWindowPID(quint32 winId);
     static bool isXEmbedKey(const QString &itemKey);
     virtual bool isValid() override {return m_valid;}
 


### PR DESCRIPTION
- fix: 修复程序同时支持XEmbed和SNI时，托盘出现双图标问题
- fix: Fixed duplicate trays in programs that support SNI and XEmbed at the same time by using QSet to record program's PID
- fix: Fixed Duplicate Tray Icons issue #142
- fix: Fixed Duplicate Tray Icons issue #142
- fix: Fixed Duplicate Tray Icons
- test: test topic
