### PR TITLE
chore: 任务栏主屏改变信号由qt接口获取，保持数据源统一

### DIFF
--- a/frame/display/displaymanager.cpp
+++ b/frame/display/displaymanager.cpp
@@ -31,17 +31,9 @@ DisplayManager::DisplayManager(QObject *parent)
     : QObject(parent)
     , m_gsettings(Utils::SettingsPtr("com.deepin.dde.dock.mainwindow", "/com/deepin/dde/dock/mainwindow/", this))
     , m_onlyInPrimary(Utils::SettingValue("com.deepin.dde.dock.mainwindow", "/com/deepin/dde/dock/mainwindow/", "onlyShowPrimary", false).toBool())
-    , m_displayInter(nullptr)
 {
     connect(qApp, &QApplication::primaryScreenChanged, this, &DisplayManager::primaryScreenChanged);
-    if (Utils::IS_WAYLAND_DISPLAY) {
-        // TODO wayland下无主屏概念，此方案并不是最优解，窗管如果扩展了这部分协议，我们可以通过协议达成此目的
-        m_displayInter = new DisplayInter("com.deepin.daemon.Display", "/com/deepin/daemon/Display",QDBusConnection::sessionBus(), this);
-        connect(m_displayInter, &__Display::PrimaryChanged, this, &DisplayManager::dockInfoChanged);
-        connect(m_displayInter, &__Display::DisplayModeChanged, this, &DisplayManager::dockInfoChanged);
-    } else {
-        connect(qApp, &QApplication::primaryScreenChanged, this, &DisplayManager::dockInfoChanged);
-    }
+    connect(qApp, &QApplication::primaryScreenChanged, this, &DisplayManager::dockInfoChanged);
     connect(qApp, &QGuiApplication::screenAdded, this, &DisplayManager::screenCountChanged);
     connect(qApp, &QGuiApplication::screenRemoved, this, &DisplayManager::screenCountChanged);
 
@@ -172,7 +164,7 @@ void DisplayManager::updateScreenDockInfo()
     // 仅显示在主屏时的处理
     if (m_onlyInPrimary) {
         for (auto s : m_screens) {
-            if (Utils::IS_WAYLAND_DISPLAY ? !s->model().contains(m_displayInter->primary()) : s != qApp->primaryScreen()) {
+            if (s != qApp->primaryScreen()) {
                 QMap <Position, bool> map;
                 map.insert(Position::Top, false);
                 map.insert(Position::Bottom, false);

--- a/frame/display/displaymanager.h
+++ b/frame/display/displaymanager.h
@@ -27,9 +27,6 @@
 #include "singleton.h"
 #include "constants.h"
 
-#include <com_deepin_daemon_display.h>
-
-using DisplayInter = com::deepin::daemon::Display;
 using namespace Dock;
 
 class QScreen;
@@ -78,7 +75,6 @@ private:
     QMap<QScreen *, QMap<Position, bool>> m_screenPositionMap;
     const QGSettings *m_gsettings;              // 多屏配置控制
     bool m_onlyInPrimary;
-    DisplayInter *m_displayInter;
 };
 
 #endif // DISPLAYMANAGER_H


### PR DESCRIPTION
之前wayland下主屏数据的错误已经在dwayland中进行了修复。这部分需要改回来

Log: 任务栏主屏改变信号由qt接口获取，保持数据源统一
Influence: 任务栏跟随主屏显示的功能
Bug: https://pms.uniontech.com/bug-view-146451.html
Change-Id: I0b9217a476ef814ca4d793e16e2c31a1b54d11cb