### PR TITLE
chore: 内存字节对其方式调整

### DIFF
--- a/frame/item/pluginsitem.h
+++ b/frame/item/pluginsitem.h
@@ -25,6 +25,8 @@
 #include "dockitem.h"
 #include "pluginsiteminterface.h"
 
+#pragma pack(push, 4)
+
 class QGSettings;
 class PluginsItem : public DockItem
 {
@@ -88,5 +90,7 @@ private:
     static QPoint MousePressPoint;
     const QGSettings *m_gsettings;
 };
+
+#pragma pack(pop)
 
 #endif // PLUGINSITEM_H


### PR DESCRIPTION
之前在i386的机器上因为字节对齐的问题导致编译失败

Log: 无
Influence: I386的编译
Change-Id: I1a67f8fd525fd149c767a32646b6322564d19a6c