### PR TITLE
chore: use GNUInstallDirs in CmakeLists

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -114,7 +114,7 @@ install(FILES ${QM_FILES}
 
 ## dev files
 install(FILES ${INTERFACES}
-    DESTINATION include/dde-dock)
+    DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dde-dock)
 
 install(FILES ${CMAKE_BINARY_DIR}/dde-dock.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
@@ -123,7 +123,7 @@ install(FILES "cmake/DdeDock/DdeDockConfig.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DdeDock)
 
 install(FILES gschema/com.deepin.dde.dock.module.gschema.xml
-    DESTINATION share/glib-2.0/schemas)
+    DESTINATION ${CMAKE_INSTALL_DATADIR}/glib-2.0/schemas)
 
 # Address Sanitizer 内存错误检测工具,打开下面的编译选项可以看到调试信息，正常运行时不需要这些信息
 #set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -g -fsanitize=address -O2")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,6 +120,10 @@ configure_file(dde-dock.pc.in dde-dock.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/dde-dock.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 
+configure_file(
+    ${CMAKE_SOURCE_DIR}/cmake/DdeDock/DdeDockConfig.cmake.in 
+    ${CMAKE_SOURCE_DIR}/cmake/DdeDock/DdeDockConfig.cmake 
+    @ONLY)
 install(FILES "cmake/DdeDock/DdeDockConfig.cmake"
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/DdeDock)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,8 +2,6 @@ cmake_minimum_required(VERSION 3.7)
 
 set(VERSION 4.0)
 
-configure_file(dde-dock.pc.in dde-dock.pc @ONLY)
-
 project(dde-dock)
 
 #set(CMAKE_VERBOSE_MAKEFILE ON)
@@ -116,6 +114,7 @@ install(FILES ${QM_FILES}
 install(FILES ${INTERFACES}
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/dde-dock)
 
+configure_file(dde-dock.pc.in dde-dock.pc @ONLY)
 install(FILES ${CMAKE_BINARY_DIR}/dde-dock.pc
     DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.7)
 
-set(VERSION 4.0)
+if (NOT DEFINED VERSION)
+    set(VERSION 4.0)
+endif()
 
 project(dde-dock)
 

--- a/cmake/DdeDock/DdeDockConfig.cmake
+++ b/cmake/DdeDock/DdeDockConfig.cmake
@@ -1,2 +1,0 @@
-set(DDE_DOCK_INCLUDE_DIR /usr/include/dde-dock)
-include_directories("${DTKCORE_INCLUDE_DIR}")

--- a/cmake/DdeDock/DdeDockConfig.cmake.in
+++ b/cmake/DdeDock/DdeDockConfig.cmake.in
@@ -1,0 +1,2 @@
+set(DDE_DOCK_INCLUDE_DIR @CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-dock)
+include_directories("${DTKCORE_INCLUDE_DIR}")

--- a/dde-dock.pc.in
+++ b/dde-dock.pc.in
@@ -1,11 +1,11 @@
-prefix=/usr
+prefix=@CMAKE_INSTALL_PREFIX@
 exec_prefix=${prefix}
-libdir=${prefix}/lib/@HOST_MULTIARCH@
-includedir=${prefix}/include/dde-dock
+libdir=@CMAKE_INSTALL_FULL_LIBDIR@
+includedir=@CMAKE_INSTALL_FULL_INCLUDEDIR@/dde-dock
 
-Name: dde dock
+Name: dde-dock
 Description: dock dev header for deepin
-Version: 1.0
+Version: @VERSION@
 Libs:
 Cflags: -I${includedir}
 Requires:

--- a/frame/CMakeLists.txt
+++ b/frame/CMakeLists.txt
@@ -92,6 +92,6 @@ if (${CMAKE_SYSTEM_PROCESSOR} STREQUAL "aarch64")
 endif()
 
 # bin
-install(TARGETS ${BIN_NAME} DESTINATION bin)
+install(TARGETS ${BIN_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 dconfig_meta_files(APPID org.deepin.dde.dock FILES ../configs/org.deepin.dde.dock.json)

--- a/plugins/keyboard-layout/CMakeLists.txt
+++ b/plugins/keyboard-layout/CMakeLists.txt
@@ -43,4 +43,4 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
 )
 
 install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins/system-trays/)
-install(FILES ./keybord_layout.json DESTINATION /etc/dde-dock/indicator)
+install(FILES ./keybord_layout.json DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/dde-dock/indicator)


### PR DESCRIPTION
1 cmake 在 install 时优先使用 GNUInstallDirs
2 修复 pkgconfig 路径
3. 适配 DdeDockConfig.cmake 路径
4. set 前 检查版本号是否已设置

相关：https://github.com/linuxdeepin/developer-center/issues/3167
