### PR TITLE
fix: 音量窗口显示在锁屏上方

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -47,7 +47,8 @@ DockPopupWindow::DockPopupWindow(QWidget *parent)
     setWindowFlags(Qt::X11BypassWindowManagerHint | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
     if (Utils::IS_WAYLAND_DISPLAY) {
         setAttribute(Qt::WA_NativeWindow);
-        windowHandle()->setProperty("_d_dwayland_window-type", "override");
+        // 谨慎修改层级，特别要注意对锁屏的影响
+        windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
     } else {
         setAttribute(Qt::WA_InputMethodEnabled, false);
     }


### PR DESCRIPTION
原因：任务栏弹窗的层级为override，锁屏的层级为onScreenDisplay，无法盖住任务栏弹窗。
修改方案：原则上不应该有应用的层级为override，将弹窗的层级降低为onScreenDisplay，经测试不会引入问题。

Log: 修复音量窗口显示在锁屏上方的问题
Bug: https://pms.uniontech.com/bug-view-123485.html
Influence: 任务栏弹窗后锁屏的场景
Change-Id: I0dcab55e0370af42f0011f41b5f5f07122f85ddc