### PR TITLE
fix(audio): 修复调整分辨率导致禁用的声音面板可以设置问题

### DIFF
--- a/plugins/sound/soundapplet.cpp
+++ b/plugins/sound/soundapplet.cpp
@@ -532,7 +532,6 @@ void SoundApplet::activePort(const QString &portId, const uint &cardId)
     for (Port *it : m_ports) {
         if (it->id() == portId && it->cardId() == cardId) {
             it->setIsActive(true);
-            enableDevice(true);
         }
         else {
             it->setIsActive(false);


### PR DESCRIPTION
对带HDMI外接音频端口的设备调整分辨率会影响端口状态，
dock会激活设备，这与产品设计不符合，禁用端口可以是激活的端口。

Log: 修复调整分辨率导致禁用的声音面板可以设置问题
Bug: https://pms.uniontech.com/bug-view-153899.html
Influence: 声音任务栏显示
Change-Id: Ic2602a1c99ba96cd91d52fb7db679b24bfc45622