### PR TITLE
fix:  任务栏音量调节面板标题部分不需要禁用

### DIFF
--- a/plugins/sound/soundapplet.cpp
+++ b/plugins/sound/soundapplet.cpp
@@ -557,9 +557,7 @@ void SoundApplet::enableDevice(bool flag)
         m_volumeSlider->setEnabled(flag);
     }
     m_volumeIconMin->setEnabled(flag);
-    m_soundShow->setEnabled(flag);
     m_volumeIconMax->setEnabled(flag);
-    m_deviceLabel->setEnabled(flag);
 }
 
 void SoundApplet::disableAllDevice()


### PR DESCRIPTION
任务栏音量调节面板标题部分只作为显示用，无输出端口时不需要设置功能禁用。以免置灰时字体显示不显示

Log: 修复无输出端口时音量面板的标题显示不明显问题
Bug: https://pms.uniontech.com/bug-view-153875.html
Influence: 音量面板的标题清晰显示