### PR TITLE
fix: 设置预览界面层级和任务栏同级

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -48,7 +48,7 @@ DockPopupWindow::DockPopupWindow(QWidget *parent)
     if (Utils::IS_WAYLAND_DISPLAY) {
         setAttribute(Qt::WA_NativeWindow);
         // 谨慎修改层级，特别要注意对锁屏的影响
-        windowHandle()->setProperty("_d_dwayland_window-type", "onScreenDisplay");
+        windowHandle()->setProperty("_d_dwayland_window-type", "dock");
     } else {
         setAttribute(Qt::WA_InputMethodEnabled, false);
     }


### PR DESCRIPTION
设置预览界面层级为dock,和任务栏同级，避免预览时将预览界面自动隐藏，造成刚开始预览就退出预览的问题

Log: 修复鼠标悬停任务栏预览窗口，预览界面闪烁一次就消失的问题
Bug: https://pms.uniontech.com/bug-view-154859.html
Influence: 正常预览应用