### PR TITLE
fix: 热插拔无线网卡后飞行模式没有显示

### DIFF
--- a/plugins/airplane-mode/airplanemodeplugin.cpp
+++ b/plugins/airplane-mode/airplanemodeplugin.cpp
@@ -51,7 +51,7 @@ void AirplaneModePlugin::init(PluginProxyInterface *proxyInter)
 {
     m_proxyInter = proxyInter;
 
-    if (supportAirplaneMode()) {
+    if (getAirplaneDconfig()) {
         m_networkInter = new NetworkInter("com.deepin.daemon.Network", "/com/deepin/daemon/Network", QDBusConnection::sessionBus(), this);
         connect(m_networkInter, &NetworkInter::WirelessAccessPointsChanged, this, &AirplaneModePlugin::onWirelessAccessPointsOrAdapterChange);
 
@@ -238,6 +238,15 @@ bool AirplaneModePlugin::supportAirplaneMode() const
     }
 
     return false;
+}
+
+bool AirplaneModePlugin::getAirplaneDconfig() const
+{
+    bool airplane = false;
+    if (m_dconfig && m_dconfig->isValid()) {
+        airplane = m_dconfig->value("networkAirplaneMode", false).toBool();
+    }
+    return airplane;
 }
 
 

--- a/plugins/airplane-mode/airplanemodeplugin.h
+++ b/plugins/airplane-mode/airplanemodeplugin.h
@@ -61,6 +61,7 @@ public:
 
 private:
     bool supportAirplaneMode() const;
+    bool getAirplaneDconfig() const;
 
 public slots:
     void refreshAirplaneEnableState();


### PR DESCRIPTION
需要关联设备信号,刷新飞行模式

Log: 飞行模式热插拔显示和隐藏
Influence: 飞行模式
Task: https://pms.uniontech.com/bug-view-155145.html