### PR TITLE
fix: update daemonDockInterface when the dde-daemon dock interface in…

### DIFF
--- a/frame/util/menuworker.cpp
+++ b/frame/util/menuworker.cpp
@@ -196,3 +196,8 @@ void MenuWorker::setAutoHide(const bool autoHide)
     m_autoHide = autoHide;
     emit autoHideChanged(m_autoHide);
 }
+
+void MenuWorker::onNotifyDaemonInterfaceUpdate(DBusDock *dockInter)
+{
+    m_dockInter = dockInter;
+}

--- a/frame/util/menuworker.h
+++ b/frame/util/menuworker.h
@@ -45,6 +45,7 @@ signals:
 
 public slots:
     void setAutoHide(const bool autoHide);
+    void onNotifyDaemonInterfaceUpdate(DBusDock *dockInter);
 
 private:
     QMenu *createMenu(QMenu *settingsMenu);

--- a/frame/util/multiscreenworker.cpp
+++ b/frame/util/multiscreenworker.cpp
@@ -1371,6 +1371,7 @@ void MultiScreenWorker::checkDaemonDockService()
                 FREE_POINT(m_dockInter);
 
                 m_dockInter = new DBusDock(serverName, "/com/deepin/dde/daemon/Dock", QDBusConnection::sessionBus(), this);
+                Q_EMIT notifyDaemonInterfaceUpdate();
                 // connect
                 connectionInit(m_dockInter);
 

--- a/frame/util/multiscreenworker.h
+++ b/frame/util/multiscreenworker.h
@@ -169,6 +169,7 @@ signals:
     void requestStopHideAni();
 
     void requestUpdateDockEntry();
+    void notifyDaemonInterfaceUpdate();
 
 public slots:
     void onAutoHideChanged(bool autoHide);

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -378,6 +378,10 @@ void MainWindow::initConnections()
     // 响应后端触控屏拖拽任务栏高度长按信号
     connect(TouchSignalManager::instance(), &TouchSignalManager::middleTouchPress, this, &MainWindow::touchRequestResizeDock);
     connect(TouchSignalManager::instance(), &TouchSignalManager::touchMove, m_dragWidget, &DragWidget::onTouchMove);
+
+    connect(m_multiScreenWorker, &MultiScreenWorker::notifyDaemonInterfaceUpdate, m_menuWorker, [this]() {
+        m_menuWorker->onNotifyDaemonInterfaceUpdate(m_multiScreenWorker->dockInter());
+    });
 }
 
 /**


### PR DESCRIPTION
…it after dde-dock

当dock比dde-daemon的dockInterface启动更早，dock会delete该interface指针后重新new
但是在menuworker里面，还是使用的未更新的dockInterface对象，即野指针
因此会导致调用接口后崩溃

Log: Update daemonDockInterface when daemon init behind dock
Influence: 注销右键点击出现菜单栏
Bug: https://pms.uniontech.com/bug-view-155357.html
Change-Id: I666c3e66f3bfbdbd66c230d8d5ea72175b355289