### PR TITLE
chore: use CMAKE_SYSTEM_PROCESSOR to check sw_64

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,15 +39,10 @@ endif ()
 set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} -DQT_DEBUG")
 
 # Test architecture
-execute_process(COMMAND dpkg-architecture -qDEB_BUILD_ARCH OUTPUT_VARIABLE ARCHITECTURE RESULT_VARIABLE EXIT_CODE)
-if (${EXIT_CODE} EQUAL 0)
-    string(STRIP ${ARCHITECTURE} ARCHITECTURE)
-
-    if (${ARCHITECTURE} STREQUAL "sw_64")
-        # add compiler flags -mieee for mathmatic
-        set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
-        add_definitions(-DDISABLE_SHOW_ANIMATION)
-    endif()
+if (${CMAKE_SYSTEM_PROCESSOR} MATCHES "sw_64")
+    # add compiler flags -mieee for mathmatic
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mieee")
+    add_definitions(-DDISABLE_SHOW_ANIMATION)
 endif()
 
 file(GLOB INTERFACES "interfaces/*.h")


### PR DESCRIPTION
dpkg-architecture 是 debian 系系统才有的，并不通用

我没有 sw_64 的机器测试，不过 CMAKE_SYSTEM_PROCESSOR 的做法在 dde 其他项目已经使用
比如 https://github.com/linuxdeepin/deepin-editor/blob/master/CMakeLists.txt#L17 ，应该没问题