### PR TITLE
fix: 将任务栏插件仅主屏显示设置的默认值设置为true

### DIFF
--- a/gschema/com.deepin.dde.dock.module.gschema.xml
+++ b/gschema/com.deepin.dde.dock.module.gschema.xml
@@ -551,7 +551,7 @@
       <description>Control duration of dock switch in monitors</description>
     </key>
     <key type="b" name="only-show-primary">
-      <default>false</default>
+      <default>true</default>
       <summary></summary>
       <description>Determine to show dock only in primary monitor</description>
     </key>


### PR DESCRIPTION
修改仅主屏显示的默认值

Log: 修改仅主屏显示的默认值为true
Bug: https://pms.uniontech.com/bug-view-151733.html
Influence: 任务栏主屏显示