### PR TITLE
fix: 修复蓝牙连接成功后动画显示问题

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -106,17 +106,21 @@ void BluetoothDeviceItem::updateIconTheme(DGuiApplicationHelper::ColorType type)
 void BluetoothDeviceItem::updateDeviceState(Device::State state)
 {
     m_labelAction->setText(m_device->alias());
+
     if (state == Device::StateAvailable) {
         m_loading->start();
+        m_loading->setVisible(true);
         m_stateAction->setVisible(true);
         m_connAction->setVisible(false);
     } else if (state == Device::StateConnected) {
         m_loading->stop();
+        m_loading->setVisible(false);
         m_stateAction->setVisible(false);
         m_connAction->setVisible(true);
         emit requestTopDeviceItem(m_standarditem);
     } else {
         m_loading->stop();
+        m_loading->setVisible(false);
         m_stateAction->setVisible(false);
         m_connAction->setVisible(false);
     }


### PR DESCRIPTION
连接需要PIN码的蓝牙设备，连接中的动画控件还停留在旧的位置，连接成功，该状态立即隐藏

Log:
Influence: 任务栏-蓝牙插件-连接需要PIN码的蓝牙设备连接成功，蓝牙列表状态显示正常
Bug: https://pms.uniontech.com/bug-view-159331.html