### PR TITLE
fix: 修复蓝牙连接成功后动画显示问题

### DIFF
--- a/frame/item/components/previewcontainer.cpp
+++ b/frame/item/components/previewcontainer.cpp
@@ -251,6 +251,12 @@ void PreviewContainer::dragLeaveEvent(QDragLeaveEvent *e)
 
 void PreviewContainer::onSnapshotClicked(const WId wid)
 {
+    if (Utils::IS_WAYLAND_DISPLAY) {
+        /* BUGFIX-159303 本地发现该问题仅在wayland下出现，问题已与窗管对接沟通过，根据窗管建议，上层进
+        规避，避免因底层强行修改引入新的问题 */
+        Q_EMIT requestCancelPreviewWindow();
+    }
+
     Q_EMIT requestActivateWindow(wid);
     m_needActivate = true;
     m_waitForShowPreviewTimer->stop();

--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -106,6 +106,7 @@ void BluetoothDeviceItem::updateIconTheme(DGuiApplicationHelper::ColorType type)
 void BluetoothDeviceItem::updateDeviceState(Device::State state)
 {
     m_labelAction->setText(m_device->alias());
+
     if (state == Device::StateAvailable) {
         m_loading->start();
         m_stateAction->setVisible(true);
@@ -120,6 +121,8 @@ void BluetoothDeviceItem::updateDeviceState(Device::State state)
         m_stateAction->setVisible(false);
         m_connAction->setVisible(false);
     }
+
+    m_loading->setVisible(state == Device::StateAvailable);
     emit deviceStateChanged(m_device);
 }
 


### PR DESCRIPTION
连接需要PIN码的蓝牙设备，连接中的动画控件还停留在旧的位置，连接成功，该状态立即隐藏

Log:
Influence: 任务栏-蓝牙插件-连接需要PIN码的蓝牙设备连接成功，蓝牙列表状态显示正常
Bug: https://pms.uniontech.com/bug-view-159331.html