### PR TITLE
fix: 修复点击预览窗口，屏幕键盘失去焦点问题

### DIFF
--- a/frame/item/components/previewcontainer.cpp
+++ b/frame/item/components/previewcontainer.cpp
@@ -251,6 +251,12 @@ void PreviewContainer::dragLeaveEvent(QDragLeaveEvent *e)
 
 void PreviewContainer::onSnapshotClicked(const WId wid)
 {
+    if (Utils::IS_WAYLAND_DISPLAY) {
+        /* BUGFIX-159303 本地发现该问题仅在wayland下出现，问题已与窗管对接沟通过，根据窗管建议，上层进
+        规避，避免因底层强行修改引入新的问题 */
+        Q_EMIT requestCancelPreviewWindow();
+    }
+
     Q_EMIT requestActivateWindow(wid);
     m_needActivate = true;
     m_waitForShowPreviewTimer->stop();


### PR DESCRIPTION
修改背景： 任务栏该模块代码很久未做改动，本地发现该问题仅在wayland下出现，问题已与窗管对接沟通过，根据窗管建议，上层进 规避，避免因底层强行修改引入新的问题
修复方式： 在wanland下，预览时点击之前取消预览，然后再激活窗口，进行规避

Log: 修复点击预览窗口，键盘失去焦点的问题
Influence: 任务栏-点击预览窗口，任务栏操作正常
Bug: https://pms.uniontech.com/bug-view-159303.html