### PR TITLE
fix: 修复osd和插件音量显示不一致的情况

### DIFF
--- a/plugins/sound/sounditem.cpp
+++ b/plugins/sound/sounditem.cpp
@@ -188,9 +188,9 @@ void SoundItem::refreshIcon()
             volumeString = "muted";
         else if (int(volmue) == 0)
             volumeString = "off";
-        else if (volmue / maxVolmue > double(2) / 3)
+        else if (volmue / maxVolmue > 0.6)
             volumeString = "high";
-        else if (volmue / maxVolmue > double(1) / 3)
+        else if (volmue / maxVolmue > 0.3)
             volumeString = "medium";
         else
             volumeString = "low";


### PR DESCRIPTION
分级标准不一致,统一修改为0.3和0.6

Log: 修复osd和插件音量显示不一致的情况
Bug: https://pms.uniontech.com/bug-view-159535.html
Influence: 音量显示
Change-Id: Ib8245c62d8c8fca30f041602294a3764c81ced6c