### PR TITLE
fix: 修复始终隐藏任务栏的配置项失效的问题

### DIFF
--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -143,6 +143,7 @@ void MainWindow::launch()
         bool showDock = true;
         if (m_dconfig.data()->isValid())
             showDock = !m_dconfig.data()->value("alwaysHideDock", false).toBool();
+        qApp->setProperty("ALWAYS_HIDE_DOCK", !showDock);
         setVisible(showDock);
         if (!showDock && m_multiScreenWorker->dockInter()) {
             m_multiScreenWorker->dockInter()->setHideMode(KeepHidden);
@@ -298,6 +299,7 @@ void MainWindow::initComponents()
         connect(m_dconfig.data(), &DConfig::valueChanged, this, [this] (const QString &key) {
             if (key == "alwaysHideDock") {
                 const bool showDock = !m_dconfig.data()->value(key, false).toBool();
+                qApp->setProperty("ALWAYS_HIDE_DOCK", !showDock);
                 setVisible(showDock);
                 if (!showDock && m_multiScreenWorker->dockInter()) {
                     m_multiScreenWorker->dockInter()->setHideMode(KeepHidden);
@@ -677,4 +679,14 @@ void MainWindow::sendNotifications()
                 .arg(15000)                                                                    // timeout
                 .call();
     });
+}
+
+void MainWindow::setVisible(bool visible)
+{
+    // 设置了始终隐藏的情况下，任务栏将永远不显示
+    if (visible && qApp->property("ALWAYS_HIDE_DOCK").toBool()) {
+        return;
+    }
+
+    return DBlurEffectWidget::setVisible(visible);
 }

--- a/frame/window/mainwindow.h
+++ b/frame/window/mainwindow.h
@@ -140,6 +140,7 @@ private:
 class MainWindow : public DBlurEffectWidget
 {
     Q_OBJECT
+    friend class MainPanelControl;
 
 public:
     explicit MainWindow(QWidget *parent = nullptr);
@@ -149,7 +150,7 @@ public:
     void setGeometry(const QRect &rect);
     void sendNotifications();
 
-    friend class MainPanelControl;
+    void setVisible(bool visible) override;
 
     MainPanelControl *panel() {return m_mainPanel;}
 


### PR DESCRIPTION
在部分时机，任务栏在设置始终隐藏后仍然会显示，例如，来回切换主屏
这是因为之前wayland下的修改，会强制显示任务栏，避免任务栏界面被qwayland库的接口隐藏

Log: 修复始终隐藏任务栏的配置项失效的问题
Influence: 任务栏的始终隐藏配置
Change-Id: Ib3f8070445a511c523f116b1668969bfd20f4690