### PR TITLE
fix: 深色系统主题下任务栏蓝牙列表的蓝牙名称显示异常

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -185,10 +185,17 @@ void BluetoothAdapterItem::onAdapterNameChanged(const QString name)
 
 void BluetoothAdapterItem::updateIconTheme(DGuiApplicationHelper::ColorType type)
 {
-    if (type == DGuiApplicationHelper::LightType)
+    QPalette widgetBackgroud;
+    if (type == DGuiApplicationHelper::LightType) {
         m_refreshBtn->setRotateIcon(":/wireless/resources/wireless/refresh_dark.svg");
-    else
+        widgetBackgroud.setColor(QPalette::Background, QColor(255, 255, 255, 0.03 * 255));
+    } else {
+        widgetBackgroud.setColor(QPalette::Background, QColor(0, 0, 0, 0.03 * 255));
         m_refreshBtn->setRotateIcon(":/wireless/resources/wireless/refresh.svg");
+    }
+
+    m_adapterLabel->label()->setAutoFillBackground(true);
+    m_adapterLabel->label()->setPalette(widgetBackgroud);
 }
 
 QSize BluetoothAdapterItem::sizeHint() const


### PR DESCRIPTION
根据系统主题的类型去调整蓝牙名称的显示

Log: 修复深色系统主题下任务栏蓝牙列表的蓝牙名称显示异常的问题
Bug: https://pms.uniontech.com/bug-view-138011.html
Influence: 任务栏蓝牙名称显示
Change-Id: I697b7304157652085dc0e8fe0ab6e407575128c8