### PR TITLE
fix: 修复蓝牙列表连接后显示异常问题

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -26,7 +26,7 @@ BluetoothDeviceItem::BluetoothDeviceItem(QStyle *style, const Device *device, DL
     , m_labelAction(nullptr)
     , m_stateAction(nullptr)
     , m_connAction(nullptr)
-    , m_loading(new DSpinner(parent))
+    , m_loading(new DSpinner(parent->viewport()))
     , m_iconWidget(new QWidget(parent->viewport()))
     , m_connButton(new StateButton(m_iconWidget))
 {
@@ -106,22 +106,24 @@ void BluetoothDeviceItem::updateIconTheme(DGuiApplicationHelper::ColorType type)
 void BluetoothDeviceItem::updateDeviceState(Device::State state)
 {
     m_labelAction->setText(m_device->alias());
+
+    m_connAction->setVisible(state == Device::StateConnected);
+    m_stateAction->setVisible(state == Device::StateAvailable);
+
     if (state == Device::StateAvailable) {
         m_loading->start();
-        m_stateAction->setVisible(true);
-        m_connAction->setVisible(false);
     } else if (state == Device::StateConnected) {
         m_loading->stop();
-        m_stateAction->setVisible(false);
-        m_connAction->setVisible(true);
         emit requestTopDeviceItem(m_standarditem);
     } else {
         m_loading->stop();
-        m_stateAction->setVisible(false);
-        m_connAction->setVisible(false);
     }
 
-    m_loading->setVisible(state == Device::StateAvailable);
+    /* 已连接的Item插入到首位后，其设置的 DViewItemAction 对象的位置未更新，导致还是显示在原位置
+    手动设置其位置到首位，触发 DViewItemAction 对象的位置更新，规避该问题，该问题待后期DTK优化 */
+    QRect loadingRect = m_loading->geometry();
+    loadingRect.setY(0);
+    m_loading->setGeometry(loadingRect);
     emit deviceStateChanged(m_device);
 }
 
@@ -171,11 +173,11 @@ void BluetoothAdapterItem::onTopDeviceItem(DStandardItem *item)
     if (!item || item->row() == -1 || item->row() == 0)
         return;
 
-    int index1 = item->row();
+    int row = item->row();
     // 先获取，再移除，后插入
-    QStandardItem *index = m_deviceModel->takeItem(index1, 0);
-    m_deviceModel->removeRow(index1);
-    m_deviceModel->insertRow(0, index);
+    QStandardItem *sItem = m_deviceModel->takeItem(row, 0);
+    m_deviceModel->removeRow(row);
+    m_deviceModel->insertRow(0, sItem);
 }
 
 void BluetoothAdapterItem::onAdapterNameChanged(const QString name)


### PR DESCRIPTION
移除QStandardItem后，与其绑定的DViewItemAction对象的geometry没有变化导致还显示在原位置 修复方案是：手动更新action的位置，后期DTK组会针对该问题进行优化。

Log:
Influence: 任务栏-蓝牙列表-连接后，列表正常显示
Bug: https://pms.uniontech.com/bug-view-159331.html