### PR TITLE
fix: 修复蓝牙列表连接后显示异常问题

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -115,15 +115,16 @@ void BluetoothDeviceItem::updateDeviceState(Device::State state)
     } else if (state == Device::StateConnected) {
         m_loading->stop();
         emit requestTopDeviceItem(m_standarditem);
+
+        /* 已连接的Item插入到首位后，其设置的 DViewItemAction 对象的位置未更新，导致还是显示在原位置
+        手动设置其位置到首位，触发 DViewItemAction 对象的位置更新，规避该问题，该问题待后期DTK优化 */
+        QRect loadingRect = m_loading->geometry();
+        loadingRect.setY(0);
+        m_loading->setGeometry(loadingRect);
     } else {
         m_loading->stop();
     }
 
-    /* 已连接的Item插入到首位后，其设置的 DViewItemAction 对象的位置未更新，导致还是显示在原位置
-    手动设置其位置到首位，触发 DViewItemAction 对象的位置更新，规避该问题，该问题待后期DTK优化 */
-    QRect loadingRect = m_loading->geometry();
-    loadingRect.setY(0);
-    m_loading->setGeometry(loadingRect);
     emit deviceStateChanged(m_device);
 }
 


### PR DESCRIPTION
移除QStandardItem后，与其绑定的DViewItemAction对象的geometry没有变化导致还显示在原位置 修复方案是：手动更新action的位置，后期DTK组会针对该问题进行优化。

Log:
Influence: 任务栏-蓝牙列表-连接后，列表正常显示
Bug: https://pms.uniontech.com/bug-view-159331.html