### PR TITLE
fix: 只有预览应用时界面圆角为18其他tips圆角为6

### DIFF
--- a/cmake/DdeDock/DdeDockConfig.cmake
+++ b/cmake/DdeDock/DdeDockConfig.cmake
@@ -1,0 +1,2 @@
+set(DDE_DOCK_INCLUDE_DIR /usr/local/include/dde-dock)
+include_directories("${DDE_DOCK_INCLUDE_DIR}")

--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -603,7 +603,7 @@ void AppItem::showPreview()
         PopupWindow->setLeftRightRadius(false);
     }
 
-    showPopupWindow(m_appPreviewTips, true);
+    showPopupWindow(m_appPreviewTips, true, 18);
 }
 
 void AppItem::playSwingEffect()

--- a/frame/item/components/appdragwidget.cpp
+++ b/frame/item/components/appdragwidget.cpp
@@ -34,7 +34,6 @@ AppDragWidget::AppDragWidget(QWidget *parent)
     m_popupWindow->setShadowXOffset(0);
     m_popupWindow->setArrowWidth(18);
     m_popupWindow->setArrowHeight(10);
-    m_popupWindow->setRadius(18);
 
     m_scene->addItem(m_object.get());
     setScene(m_scene);

--- a/frame/item/dockitem.cpp
+++ b/frame/item/dockitem.cpp
@@ -30,7 +30,7 @@ DockItem::DockItem(QWidget *parent)
     if (PopupWindow.isNull()) {
         DockPopupWindow *arrowRectangle = new DockPopupWindow(nullptr);
         arrowRectangle->setShadowBlurRadius(20);
-        arrowRectangle->setRadius(18);
+        arrowRectangle->setRadius(6);
         arrowRectangle->setShadowYOffset(2);
         arrowRectangle->setShadowXOffset(0);
         arrowRectangle->setArrowWidth(18);
@@ -270,13 +270,9 @@ void DockItem::showHoverTips()
     showPopupWindow(content);
 }
 
-void DockItem::showPopupWindow(QWidget *const content, const bool model)
+void DockItem::showPopupWindow(QWidget *const content, const bool model, const int radius)
 {
-    if(itemType() == App){
-        PopupWindow->setRadius(18);
-    }else {
-        PopupWindow->setRadius(6);
-    }
+    PopupWindow->setRadius(radius);
 
     m_popupShown = true;
     m_lastPopupWidget = content;

--- a/frame/item/dockitem.h
+++ b/frame/item/dockitem.h
@@ -72,7 +72,7 @@ protected:
 
     void hideNonModel();
     void popupWindowAccept();
-    virtual void showPopupWindow(QWidget *const content, const bool model = false);
+    virtual void showPopupWindow(QWidget *const content, const bool model = false, const int radius = 6);
     virtual void showHoverTips();
     virtual void invokedMenuItem(const QString &itemId, const bool checked);
     virtual const QString contextMenu() const;

--- a/frame/item/pluginsitem.cpp
+++ b/frame/item/pluginsitem.cpp
@@ -242,9 +242,9 @@ void PluginsItem::invokedMenuItem(const QString &itemId, const bool checked)
     m_pluginInter->invokedMenuItem(m_itemKey, itemId, checked);
 }
 
-void PluginsItem::showPopupWindow(QWidget *const content, const bool model)
+void PluginsItem::showPopupWindow(QWidget *const content, const bool model, const int radius)
 {
-    DockItem::showPopupWindow(content, model);
+    DockItem::showPopupWindow(content, model, radius);
 }
 
 const QString PluginsItem::contextMenu() const

--- a/frame/item/pluginsitem.h
+++ b/frame/item/pluginsitem.h
@@ -50,7 +50,7 @@ protected:
     void showEvent(QShowEvent *event) override;
 
     void invokedMenuItem(const QString &itemId, const bool checked) override;
-    void showPopupWindow(QWidget *const content, const bool model = false) override;
+    void showPopupWindow(QWidget *const content, const bool model = false, const int radius = 6) override;
     const QString contextMenu() const override;
     QWidget *popupTips() override;
     void resizeEvent(QResizeEvent *event) override;

--- a/widgets/tipswidget.cpp
+++ b/widgets/tipswidget.cpp
@@ -8,6 +8,8 @@
 #include <QAccessible>
 #include <QTextDocument>
 
+#define PADDING 4
+
 namespace Dock{
 TipsWidget::TipsWidget(QWidget *parent)
     : QFrame(parent)
@@ -30,7 +32,7 @@ void TipsWidget::setText(const QString &text)
     m_text = "བོད་སྐད་ཡིག་གཟུགས་ཚད་ལེན་ཚོད་ལྟའི་སྐོར་གྱི་རྗོད་ཚིག";
 #endif
 
-    setFixedSize(fontMetrics().width(m_text) + 20, fontMetrics().boundingRect(m_text).height());
+    setFixedSize(fontMetrics().width(m_text) + 20, fontMetrics().boundingRect(m_text).height() + PADDING);
 
     update();
 
@@ -54,7 +56,7 @@ void TipsWidget::setTextList(const QStringList &textList)
         height += fontMetrics().boundingRect(text).height();
     }
 
-    setFixedSize(width + 20, height);
+    setFixedSize(width + 20, height + PADDING);
 
     update();
 }


### PR DESCRIPTION
只有预览应用时界面圆角为18其他tips圆角为6, 并且tips高度根据内容计算高度再加4像素

Log: 修复任务栏应用tips框样式问题
Bug: https://pms.uniontech.com/bug-view-166289.html
Influence: 任务栏tips正常显示