### PR TITLE
fix: avoid hardcoded exec path

### DIFF
--- a/plugins/overlay-warning/com.deepin.dde.dock.overlay.policy
+++ b/plugins/overlay-warning/com.deepin.dde.dock.overlay.policy
@@ -13,20 +13,7 @@
       <allow_active>auth_admin_keep</allow_active>
     </defaults>
     <message xml:lang="zh_CN">本次启动处于 overlay 保护模式下，您的所有操作将不会被保存，是否要关闭此模式并重启？</message>
-    <annotate key="org.freedesktop.policykit.exec.path">/sbin/overlayroot-disable</annotate>
+    <annotate key="org.freedesktop.policykit.exec.path">overlayroot-disable</annotate>
     <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
   </action>
-    <action id="com.deepin.dde.dock.overlay1">
-    <icon_name>dialog-warning</icon_name>
-    <message>The system is in overlay mode, and all your work will not be saved. Do you want to exit this mode and restart?</message>
-    <defaults>
-      <allow_any>no</allow_any>
-      <allow_inactive>no</allow_inactive>
-      <allow_active>auth_admin_keep</allow_active>
-    </defaults>
-    <message xml:lang="zh_CN">本次启动处于 overlay 保护模式下，您的所有操作将不会被保存，是否要关闭此模式并重启？</message>
-    <annotate key="org.freedesktop.policykit.exec.path">/usr/sbin/overlayroot-disable</annotate>
-    <annotate key="org.freedesktop.policykit.exec.allow_gui">true</annotate>
-  </action>
-
 </policyconfig>

--- a/plugins/overlay-warning/overlay-warning-plugin.cpp
+++ b/plugins/overlay-warning/overlay-warning-plugin.cpp
@@ -174,7 +174,7 @@ void OverlayWarningPlugin::showCloseOverlayDialogPre()
 void OverlayWarningPlugin::showCloseOverlayDialog()
 {
     qDebug() << "start disable overlayroot process";
-    const int result = QProcess::execute("/usr/bin/pkexec /usr/sbin/overlayroot-disable");
+    const int result = QProcess::execute("pkexec overlayroot-disable");
     if (result == 0) {
         QProcess::startDetached("reboot");
     } else {


### PR DESCRIPTION
use executable names directly instead of absolute paths in plugins/overlay-warning/overlay-warning-plugin.cpp; replace /sbin/overlayroot-disable with overlayroot-disable in plugins/overlay-warning/com.deepin.dde.dock.overlay.policy and remove now redundant action entry

Related: linuxdeepin/developer-center#3374

The commit message should be fixed now. Not sure about the license issue which isn't introduced by this PR; hopefully it's not a blocker for merging this PR.