### PR TITLE
fix: 修复在显示其他插件的Tips时无法弹出网络列表输入密码问题

### DIFF
--- a/cmake/DdeDock/DdeDockConfig.cmake
+++ b/cmake/DdeDock/DdeDockConfig.cmake
@@ -1,2 +1,0 @@
-set(DDE_DOCK_INCLUDE_DIR /usr/local/include/dde-dock)
-include_directories("${DDE_DOCK_INCLUDE_DIR}")

--- a/frame/controller/dockpluginscontroller.cpp
+++ b/frame/controller/dockpluginscontroller.cpp
@@ -110,6 +110,21 @@ void DockPluginsController::requestSetAppletVisible(PluginsItemInterface *const 
         return;
 
     if (visible) {
+        // 在弹出界面前先隐藏其他插件的tips
+        QMap<PluginsItemInterface *, QMap<QString, QObject *>> &mPluginsMap = pluginsMap();
+        foreach (auto interface, mPluginsMap.keys()) {
+            if (interface != itemInter) {
+                foreach (auto oldItemKey, mPluginsMap[interface].keys()) {
+                    if (oldItemKey != "pluginloader") {
+                        PluginsItem *oldItem = qobject_cast<PluginsItem *>(pluginItemAt(interface, oldItemKey));
+                        if (oldItem) {
+                            oldItem->hidePopup();
+                        }
+                    }
+                }
+            }
+        }
+
         item->showPopupApplet(itemInter->itemPopupApplet(itemKey));
     } else {
         item->hidePopup();

--- a/plugins/tray/system-trays/systemtrayscontroller.cpp
+++ b/plugins/tray/system-trays/systemtrayscontroller.cpp
@@ -97,6 +97,21 @@ void SystemTraysController::requestSetAppletVisible(PluginsItemInterface * const
         return;
 
     if (visible) {
+        // 在弹出界面前先隐藏其他插件的tips
+        QMap<PluginsItemInterface *, QMap<QString, QObject *>> &mPluginsMap = pluginsMap();
+        foreach (auto interface, mPluginsMap.keys()) {
+            if (interface != itemInter) {
+                foreach (auto oldItemKey, mPluginsMap[interface].keys()) {
+                    if (oldItemKey != "pluginloader") {
+                        SystemTrayItem *oldItem = qobject_cast<SystemTrayItem *>(pluginItemAt(interface, oldItemKey));
+                        if (oldItem) {
+                            oldItem->hidePopup();
+                        }
+                    }
+                }
+            }
+        }
+
         item->showPopupApplet(itemInter->itemPopupApplet(itemKey));
     } else {
         item->hidePopup();


### PR DESCRIPTION
修复在显示其他插件的Tips时无法弹出网络列表输入密码问题

Log: 修复在显示其他插件的Tips时无法弹出网络列表输入密码问题
Task: https://pms.uniontech.com/task-view-212979.html
Influence: 在显示其他插件的TIps或控制面板时，网络列表正常弹出