### PR TITLE
feat: 隐藏显示动画调整

### DIFF
--- a/configs/org.deepin.dde.dock.json
+++ b/configs/org.deepin.dde.dock.json
@@ -37,6 +37,17 @@
             "description":"show(or restore) desktop will toggle after the hover interval (in milliseconds)",
             "permissions":"readwrite",
             "visibility":"private"
+        },
+        "delayDisplay":{
+            "value": 0,
+            "serial": 0,
+            "flags":[],
+            "name":"delayDisplay",
+            "name[zh_CN]":"任务栏延时显示时间",
+            "description[zh_CN]":"任务栏智能隐藏或一直隐藏时，鼠标移动到屏幕边缘过一段时间再唤起任务栏（以毫秒为单位）",
+            "description":"When the dock is hidden, move the mouse to the edge of the screen and then recall the dock (in milliseconds)",
+            "permissions":"readwrite",
+            "visibility":"private"
         }
     }
 }

--- a/frame/util/multiscreenworker.h
+++ b/frame/util/multiscreenworker.h
@@ -103,6 +103,8 @@ public:
         TouchPress = 0x20,                  // 当前触摸屏下是否按下
         LauncherDisplay = 0x40,             // 启动器是否显示
         DockIsShowing = 0x80,               // 任务栏正在显示
+        CheckDockShouldDisplay = 0x100,     // 任务栏已经隐藏时，正在判断是否需要显示
+
 
         // 如果要添加新的状态，可以在上面添加
         RunState_Mask = 0xffffffff,
@@ -164,6 +166,7 @@ private slots:
     // Region Monitor
     void onRegionMonitorChanged(int x, int y, const QString &key);
     void onExtralRegionMonitorChanged(int x, int y, const QString &key);
+    void CheckShouldDisplay(int x, int y, const QString &key);
 
     // Animation
     void showAniFinished();
@@ -248,6 +251,8 @@ private:
     // update monitor info
     QTimer *m_monitorUpdateTimer;
     QTimer *m_delayWakeTimer;                   // sp3需求，切换屏幕显示延时，默认2秒唤起任务栏
+    QTimer *m_delayDisplay;                     // 任务栏隐藏时，鼠标移动到屏幕边缘，延时唤起任务栏
+    QPoint m_delayDisplayPos;
 
     DockScreen m_ds;                            // 屏幕名称信息
     ScreenChangeMonitor *m_screenMonitor;       // 用于监视屏幕是否为系统先拔再插


### PR DESCRIPTION
任务栏智能隐藏或一直隐藏时，鼠标移动到屏幕边缘过一段时间再唤起任务栏
DConfig配置：delayDisplay，默认值0，单位毫秒

Log: 隐藏显示动画调整
Change-Id: I6d8a41557559fa4f259425a930fc436626229337