### PR TITLE
fix: 点击任务栏蓝牙设置不能正常唤起控制中心

### DIFF
--- a/plugins/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/bluetooth/componments/bluetoothapplet.cpp
@@ -173,6 +173,11 @@ void BluetoothApplet::onAdapterAdded(Adapter *adapter)
 
     m_adapterItems.insert(adapter->id(), adapterItem);
 
+    // 如果开启了飞行模式，置灰蓝牙适配器使能开关
+    foreach (const auto item, m_adapterItems) {
+        item->setEnabled(!m_airPlaneModeInter->enabled());
+    }
+
     m_contentLayout->insertWidget(0, adapterItem, Qt::AlignTop | Qt::AlignVCenter);
     updateBluetoothPowerState();
     updateSize();
@@ -247,7 +252,6 @@ void BluetoothApplet::initUi()
     updateSize();
 
     setAirplaneModeEnabled(m_airPlaneModeInter->enabled());
-    setDisabled(m_airPlaneModeInter->enabled());
 }
 
 void BluetoothApplet::initConnect()
@@ -266,7 +270,11 @@ void BluetoothApplet::initConnect()
     });
     connect(DApplicationHelper::instance(), &DApplicationHelper::themeTypeChanged, this, &BluetoothApplet::updateIconTheme);
     connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, &BluetoothApplet::setAirplaneModeEnabled);
-    connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, &BluetoothApplet::setDisabled);
+    connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, [this](bool enabled) {
+        foreach (const auto item, m_adapterItems) {
+            item->setEnabled(!enabled);
+        }
+    });
 }
 
 /**


### PR DESCRIPTION
当开启飞行模式后，只禁用(置灰）蓝牙适配器列表一栏，而不是置灰整个蓝牙面板

Log: 修复点击任务栏蓝牙设置不能正常唤起控制中心的问题
Bug: https://pms.uniontech.com/bug-view-171999.html
Influence: 任务栏蓝牙面板正常显示/正常使用
Change-Id: Ib1549cf28736ce2dc780b9b0427a7a472dbd4ab8