### PR TITLE
fix: 修改蓝牙刷新图标为空问题

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -190,11 +190,11 @@ void BluetoothAdapterItem::updateIconTheme(DGuiApplicationHelper::ColorType type
 {
     QPalette widgetBackgroud;
     if (type == DGuiApplicationHelper::LightType) {
-        m_refreshBtn->setRotateIcon(":/wireless/resources/wireless/refresh_dark.svg");
+        m_refreshBtn->setRotateIcon(":/refresh_dark.svg");
         widgetBackgroud.setColor(QPalette::Background, QColor(255, 255, 255, 0.03 * 255));
     } else {
         widgetBackgroud.setColor(QPalette::Background, QColor(0, 0, 0, 0.03 * 255));
-        m_refreshBtn->setRotateIcon(":/wireless/resources/wireless/refresh.svg");
+        m_refreshBtn->setRotateIcon(":/refresh.svg");
     }
 
     m_adapterLabel->label()->setAutoFillBackground(true);


### PR DESCRIPTION
刷新图标资源应为蓝牙资源内

Log: 修改蓝牙刷新图标为空问题
Bug: https://pms.uniontech.com/bug-view-172931.html
Influence: 任务栏-蓝牙列表-蓝牙刷新图标