### PR TITLE
feat: 修改屏幕键盘和回收站默认在任务栏不显示

### DIFF
--- a/plugins/onboard/onboardplugin.cpp
+++ b/plugins/onboard/onboardplugin.cpp
@@ -68,7 +68,7 @@ void OnboardPlugin::pluginStateSwitched()
 
 bool OnboardPlugin::pluginIsDisable()
 {
-    return !(m_proxyInter->getValue(this, PLUGIN_STATE_KEY, true).toBool());
+    return !(m_proxyInter->getValue(this, PLUGIN_STATE_KEY, false).toBool());
 }
 
 const QString OnboardPlugin::itemCommand(const QString &itemKey)
@@ -180,8 +180,7 @@ void OnboardPlugin::loadPlugin()
 
 void OnboardPlugin::refreshPluginItemsVisible()
 {
-    if (pluginIsDisable())
-    {
+    if (pluginIsDisable()) {
         m_proxyInter->itemRemoved(this, pluginName());
     } else {
         if (!m_pluginLoaded) {

--- a/plugins/trash/trashplugin.cpp
+++ b/plugins/trash/trashplugin.cpp
@@ -121,7 +121,7 @@ void TrashPlugin::invokedMenuItem(const QString &itemKey, const QString &menuId,
 
 bool TrashPlugin::pluginIsDisable()
 {
-    return !m_proxyInter->getValue(this, PLUGIN_STATE_KEY, true).toBool();
+    return !m_proxyInter->getValue(this, PLUGIN_STATE_KEY, false).toBool();
 }
 
 void TrashPlugin::pluginStateSwitched()


### PR DESCRIPTION
修改屏幕键盘和回收站默认在任务栏不显示

Log: 修改屏幕键盘和回收站默认在任务栏不显示
Task: https://pms.uniontech.com/task-view-212929.html
Influence: 屏幕键盘和回收站默认在任务栏不显示