### PR TITLE
fix: 修复任务栏图标模糊问题 (#729)

### DIFF
--- a/frame/main.cpp
+++ b/frame/main.cpp
@@ -171,7 +171,7 @@ int main(int argc, char *argv[])
     app.setApplicationVersion("2.0");
     app.loadTranslator();
     app.setAttribute(Qt::AA_EnableHighDpiScaling, true);
-    app.setAttribute(Qt::AA_UseHighDpiPixmaps, false);
+    app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
     // 自动化标记由此开始
     QAccessible::installFactory(accessibleFactory);

--- a/frame/util/imageutil.cpp
+++ b/frame/util/imageutil.cpp
@@ -7,7 +7,6 @@
 #include <QIcon>
 #include <QPainter>
 #include <QCursor>
-#include <QGSettings>
 #include <QDebug>
 
 #include <X11/Xcursor/Xcursor.h>
@@ -15,13 +14,14 @@
 const QPixmap ImageUtil::loadSvg(const QString &iconName, const QString &localPath, const int size, const qreal ratio)
 {
     QIcon icon = QIcon::fromTheme(iconName);
+    int pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : int(size * ratio);
     if (!icon.isNull()) {
-        QPixmap pixmap = icon.pixmap(int(size * ratio), int(size * ratio));
+        QPixmap pixmap = icon.pixmap(pixmapSize);
         pixmap.setDevicePixelRatio(ratio);
         return pixmap;
     }
 
-    QPixmap pixmap(int(size * ratio), int(size * ratio));
+    QPixmap pixmap(pixmapSize, pixmapSize);
     QString localIcon = QString("%1%2%3").arg(localPath).arg(iconName).arg(iconName.contains(".svg") ? "" : ".svg");
     QSvgRenderer renderer(localIcon);
     pixmap.fill(Qt::transparent);

--- a/plugins/multitasking/CMakeLists.txt
+++ b/plugins/multitasking/CMakeLists.txt
@@ -4,7 +4,10 @@ set(PLUGIN_NAME "multitasking")
 project(${PLUGIN_NAME})
 
 # Sources files
-file(GLOB SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp")
+file(GLOB SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp"
+    "../../frame/util/imageutil.h"
+    "../../frame/util/imageutil.cpp"
+    )
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/plugins/multitasking/multitaskingwidget.cpp
+++ b/plugins/multitasking/multitaskingwidget.cpp
@@ -4,6 +4,7 @@
 
 #include "multitaskingwidget.h"
 #include "multitaskingplugin.h"
+#include "imageutil.h"
 
 #include <QPainter>
 #include <QIcon>
@@ -29,9 +30,9 @@ void MultitaskingWidget::paintEvent(QPaintEvent *e)
     QPixmap icon;
 
     if (Dock::Fashion == qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>()) {
-        icon = QIcon::fromTheme("deepin-multitasking-view", m_icon).pixmap(size() * 0.8 * ratio);
+        icon = ImageUtil::loadSvg("deepin-multitasking-view", QString(":/icons/"), int(size().width() * 0.8), ratio);
     } else {
-        icon = QIcon::fromTheme("deepin-multitasking-view", m_icon).pixmap(size() * 0.7 * ratio);
+        icon = ImageUtil::loadSvg("deepin-multitasking-view", QString(":/icons/"), int(size().width() * 0.7), ratio);
     }
 
     icon.setDevicePixelRatio(ratio);

--- a/plugins/onboard/onboarditem.cpp
+++ b/plugins/onboard/onboarditem.cpp
@@ -95,7 +95,8 @@ const QPixmap OnboardItem::loadSvg(const QString &fileName, const QSize &size) c
     const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
-    pixmap = QIcon::fromTheme(fileName, m_icon).pixmap(size * ratio);
+    QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : (size * ratio);
+    pixmap = QIcon::fromTheme(fileName, m_icon).pixmap(pixmapSize);
     pixmap.setDevicePixelRatio(ratio);
 
     return pixmap;

--- a/plugins/overlay-warning/overlaywarningwidget.cpp
+++ b/plugins/overlay-warning/overlaywarningwidget.cpp
@@ -50,7 +50,8 @@ const QPixmap OverlayWarningWidget::loadSvg(const QString &fileName, const QSize
     const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
-    pixmap = QIcon::fromTheme(fileName).pixmap(size * ratio);
+    QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : (size * ratio);
+    pixmap = QIcon::fromTheme(fileName).pixmap(pixmapSize);
     pixmap.setDevicePixelRatio(ratio);
 
     return pixmap;

--- a/plugins/power/powerstatuswidget.cpp
+++ b/plugins/power/powerstatuswidget.cpp
@@ -96,8 +96,9 @@ QPixmap PowerStatusWidget::getBatteryIcon()
         iconStr.append(PLUGIN_MIN_ICON_NAME);
 
     const auto ratio = devicePixelRatioF();
+    QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? QSize(20, 20) : (QSize(20, 20) * ratio);
     QPixmap pix = QIcon::fromTheme(iconStr,
-                                   QIcon::fromTheme(":/batteryicons/resources/batteryicons/" + iconStr + ".svg")).pixmap(QSize(20, 20) * ratio);
+                                   QIcon::fromTheme(":/batteryicons/resources/batteryicons/" + iconStr + ".svg")).pixmap(pixmapSize);
     pix.setDevicePixelRatio(ratio);
 
     return pix;

--- a/plugins/show-desktop/CMakeLists.txt
+++ b/plugins/show-desktop/CMakeLists.txt
@@ -4,7 +4,10 @@ set(PLUGIN_NAME "show-desktop")
 project(${PLUGIN_NAME})
 
 # Sources files
-file(GLOB SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp")
+file(GLOB SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp"
+    "../../frame/util/imageutil.h"
+    "../../frame/util/imageutil.cpp"
+    )
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/plugins/show-desktop/showdesktopwidget.cpp
+++ b/plugins/show-desktop/showdesktopwidget.cpp
@@ -4,6 +4,7 @@
 
 #include "showdesktopwidget.h"
 #include "showdesktopplugin.h"
+#include "imageutil.h"
 
 #include <QPainter>
 #include <QIcon>
@@ -27,9 +28,9 @@ void ShowDesktopWidget::paintEvent(QPaintEvent *e)
     QPixmap icon;
 
     if (Dock::Fashion == qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>()) {
-        icon = QIcon::fromTheme("deepin-toggle-desktop").pixmap(size() * 0.8 * ratio);
+        icon = ImageUtil::loadSvg("deepin-toggle-desktop", QString(), int(size().width() * 0.8), ratio);
     } else {
-        icon = QIcon::fromTheme("deepin-toggle-desktop").pixmap(size() * 0.7 * ratio);
+        icon = ImageUtil::loadSvg("deepin-toggle-desktop", QString(), int(size().width() * 0.7), ratio);
     }
 
     icon.setDevicePixelRatio(ratio);

--- a/plugins/shutdown/CMakeLists.txt
+++ b/plugins/shutdown/CMakeLists.txt
@@ -4,7 +4,10 @@ set(PLUGIN_NAME "shutdown")
 project(${PLUGIN_NAME})
 
 # Sources files
-file(GLOB_RECURSE SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp")
+file(GLOB_RECURSE SRCS "*.h" "*.cpp" "../../widgets/*.h" "../../widgets/*.cpp"
+    "../../frame/util/imageutil.h"
+    "../../frame/util/imageutil.cpp"
+    )
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/plugins/shutdown/shutdownwidget.cpp
+++ b/plugins/shutdown/shutdownwidget.cpp
@@ -3,6 +3,7 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "shutdownwidget.h"
+#include "../frame/util/imageutil.h"
 
 #include <QSvgRenderer>
 #include <QPainter>
@@ -99,7 +100,8 @@ const QPixmap ShutdownWidget::loadSvg(const QString &fileName, const QSize &size
     const auto ratio = devicePixelRatioF();
 
     QPixmap pixmap;
-    pixmap = QIcon::fromTheme(fileName, m_icon).pixmap(size * ratio);
+    QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : (size * ratio);
+    pixmap = QIcon::fromTheme(fileName, m_icon).pixmap(pixmapSize);
     pixmap.setDevicePixelRatio(ratio);
 
     return pixmap;

--- a/plugins/trash/trashwidget.cpp
+++ b/plugins/trash/trashwidget.cpp
@@ -195,7 +195,8 @@ void TrashWidget::updateIcon()
     QIcon icon = QIcon::fromTheme(iconString, m_defaulticon);
 
     const auto ratio = devicePixelRatioF();
-    m_icon = icon.pixmap(size * ratio, size * ratio);
+    int pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : int(size * ratio);
+    m_icon = icon.pixmap(pixmapSize, pixmapSize);
     m_icon.setDevicePixelRatio(ratio);
 }
 


### PR DESCRIPTION
高分屏支持设置错误

Log: 修复任务栏图标模糊问题
Bug: https://pms.uniontech.com/bug-view-174459.html Influence: 缩放后任务栏-各插件图标，右键菜单图标
(cherry picked from commit 3e26d6ca35196130657e13e7361be08542ba8195)