### PR TITLE
fix: 蓝牙设备不可用时使能开关按钮

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -139,6 +139,7 @@ BluetoothAdapterItem::BluetoothAdapterItem(Adapter *adapter, QWidget *parent)
     , m_refreshBtn(new RefreshButton(this))
     , m_bluetoothInter(new DBusBluetooth("com.deepin.daemon.Bluetooth", "/com/deepin/daemon/Bluetooth", QDBusConnection::sessionBus(), this))
     , m_showUnnamedDevices(false)
+    , m_stateBtnEnabled(true)
     , m_seperator(new HorizontalSeperator(this))
 {
     initData();
@@ -224,6 +225,17 @@ QStringList BluetoothAdapterItem::connectedDevicesName()
     }
 
     return devsName;
+}
+
+void BluetoothAdapterItem::setStateBtnEnabled(bool enable)
+{
+    if (m_stateBtnEnabled != enable) {
+        m_stateBtnEnabled = enable;
+    }
+
+    if (m_adapterStateBtn) {
+        m_adapterStateBtn->setEnabled(m_stateBtnEnabled);
+    }
 }
 
 void BluetoothAdapterItem::initData()
@@ -381,7 +393,7 @@ void BluetoothAdapterItem::initConnect()
         m_deviceListview->setVisible(state);
         m_seperator->setVisible(state);
         m_adapterStateBtn->setChecked(state);
-        m_adapterStateBtn->setEnabled(true);
+        m_adapterStateBtn->setEnabled(m_stateBtnEnabled);
         emit adapterPowerChanged();
     });
     connect(m_adapterStateBtn, &DSwitchButton::clicked, this, [ = ](bool state) {

--- a/plugins/bluetooth/componments/bluetoothadapteritem.h
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.h
@@ -84,6 +84,7 @@ public:
     ~BluetoothAdapterItem();
     Adapter *adapter() { return m_adapter; }
     QStringList connectedDevicesName();
+    void setStateBtnEnabled(bool);
 
 public slots:
     // 添加蓝牙设备
@@ -125,6 +126,7 @@ private:
     RefreshButton *m_refreshBtn;
     DBusBluetooth *m_bluetoothInter;
     bool m_showUnnamedDevices;
+    bool m_stateBtnEnabled;
 
     QMap<QString, BluetoothDeviceItem *> m_deviceItems;
     HorizontalSeperator *m_seperator;

--- a/plugins/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/bluetooth/componments/bluetoothapplet.cpp
@@ -43,31 +43,12 @@ SettingLabel::SettingLabel(QString text, QWidget *parent)
     this->setPalette(p);
 
     m_label->setForegroundRole(QPalette::BrightText);
-    updateEnabledStatus();
 }
 
 void SettingLabel::addButton(QWidget *button, int space)
 {
     m_layout->addWidget(button, 0, Qt::AlignRight | Qt::AlignHCenter);
     m_layout->addSpacing(space);
-}
-
-void SettingLabel::updateEnabledStatus()
-{
-    QPalette p = m_label->palette();
-    if (m_label->isEnabled())
-        p.setColor(QPalette::BrightText, QColor(0, 0, 0));
-    else
-        p.setColor(QPalette::BrightText, QColor(51, 51, 51));
-    m_label->setPalette(p);
-}
-
-void SettingLabel::changeEvent(QEvent *event)
-{
-    if (event->type() == QEvent::EnabledChange)
-        updateEnabledStatus();
-
-    QWidget::changeEvent(event);
 }
 
 void SettingLabel::mousePressEvent(QMouseEvent *ev)
@@ -175,7 +156,7 @@ void BluetoothApplet::onAdapterAdded(Adapter *adapter)
 
     // 如果开启了飞行模式，置灰蓝牙适配器使能开关
     foreach (const auto item, m_adapterItems) {
-        item->setEnabled(!m_airPlaneModeInter->enabled());
+        item->setStateBtnEnabled(!m_airPlaneModeInter->enabled());
     }
 
     m_contentLayout->insertWidget(0, adapterItem, Qt::AlignTop | Qt::AlignVCenter);
@@ -272,7 +253,7 @@ void BluetoothApplet::initConnect()
     connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, &BluetoothApplet::setAirplaneModeEnabled);
     connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, [this](bool enabled) {
         foreach (const auto item, m_adapterItems) {
-            item->setEnabled(!enabled);
+            item->setStateBtnEnabled(!enabled);
         }
     });
 }

--- a/plugins/bluetooth/componments/bluetoothapplet.h
+++ b/plugins/bluetooth/componments/bluetoothapplet.h
@@ -46,9 +46,6 @@ signals:
 protected:
     void mousePressEvent(QMouseEvent *ev) override;
     void paintEvent(QPaintEvent *event) override;
-    void changeEvent(QEvent *event) override;
-
-    void updateEnabledStatus();
 
 private:
     DLabel *m_label;


### PR DESCRIPTION
1、删除使用错误的调色板，直接使用系统默认调色板。
2、蓝牙设备不可用时使能开关按钮，不禁用整个界面，避免界面文字内容显示不清晰

Log: 控制中心-个性化内设置为深色，从任务栏打开蓝牙面板后，蓝牙设置字体未变成浅色
Bug: https://pms.uniontech.com/bug-view-176333.html
Influence: 蓝牙设置字体跟随系统主题变化