### PR TITLE
fix: wayland下最小化魔灯效果显示异常

### DIFF
--- a/frame/controller/dockitemmanager.cpp
+++ b/frame/controller/dockitemmanager.cpp
@@ -35,7 +35,9 @@ DockItemManager::DockItemManager(QObject *parent)
         connect(it, &AppItem::requestActivateWindow, m_appInter, &DBusDock::ActivateWindow, Qt::QueuedConnection);
         connect(it, &AppItem::requestPreviewWindow, m_appInter, &DBusDock::PreviewWindow);
         connect(it, &AppItem::requestCancelPreview, m_appInter, &DBusDock::CancelPreviewWindow);
-
+        connect(it, &AppItem::requestUpdateItemMinimizedGeometry, this, [=](const QRect r){
+            Q_EMIT requestUpdateItemMinimizedGeometry(it, r);
+        });
         connect(this, &DockItemManager::requestUpdateDockItem, it, &AppItem::requestUpdateEntryGeometries);
 
         m_itemList.append(it);
@@ -194,6 +196,9 @@ void DockItemManager::appItemAdded(const QDBusObjectPath &path, const int index)
     connect(item, &AppItem::requestActivateWindow, m_appInter, &DBusDock::ActivateWindow, Qt::QueuedConnection);
     connect(item, &AppItem::requestPreviewWindow, m_appInter, &DBusDock::PreviewWindow);
     connect(item, &AppItem::requestCancelPreview, m_appInter, &DBusDock::CancelPreviewWindow);
+    connect(item, &AppItem::requestUpdateItemMinimizedGeometry, this, [=](const QRect r){
+        Q_EMIT requestUpdateItemMinimizedGeometry(item, r);
+    });
     connect(this, &DockItemManager::requestUpdateDockItem, item, &AppItem::requestUpdateEntryGeometries);
 
     m_itemList.insert(insertIndex, item);

--- a/frame/controller/dockitemmanager.h
+++ b/frame/controller/dockitemmanager.h
@@ -16,6 +16,7 @@
 #include <QObject>
 
 using DBusDock = com::deepin::dde::daemon::Dock;
+
 /**
  * @brief The DockItemManager class
  * 管理类，管理所有的应用数据，插件数据
@@ -39,8 +40,8 @@ signals:
     void trayVisableCountChanged(const int &count) const;
     void requestWindowAutoHide(const bool autoHide) const;
     void requestRefershWindowVisible() const;
-
     void requestUpdateDockItem() const;
+    void requestUpdateItemMinimizedGeometry(AppItem *item, const QRect) const;
 
 public slots:
     void refreshItemsIcon();

--- a/frame/item/appitem.h
+++ b/frame/item/appitem.h
@@ -40,14 +40,15 @@ public:
     inline ItemType itemType() const override { return App; }
     QPixmap appIcon(){ return m_appIcon; }
     virtual QString accessibleName() override;
+    inline quint32 getAppItemWindowId() const { return  m_currentWindowId; }
 
 signals:
     void requestActivateWindow(const WId wid) const;
     void requestPreviewWindow(const WId wid) const;
     void requestCancelPreview() const;
     void dragReady(QWidget *dragWidget);
-
     void requestUpdateEntryGeometries() const;
+    void requestUpdateItemMinimizedGeometry(const QRect) const;
 
 private:
     void moveEvent(QMoveEvent *e) override;
@@ -105,6 +106,7 @@ private:
     bool m_active;
     int m_retryTimes;
     bool m_iconValid;
+    quint32 m_currentWindowId;
     quint64 m_lastclickTimes;
 
     WindowInfoMap m_windowInfos;

--- a/frame/window/mainpanelcontrol.h
+++ b/frame/window/mainpanelcontrol.h
@@ -37,6 +37,7 @@ public slots:
     void insertItem(const int index, DockItem *item);
     void removeItem(DockItem *item);
     void itemUpdated(DockItem *item);
+    void setKwinAppItemMinimizedGeometry(DockItem *item, const QRect);
 
 signals:
     void itemMoved(DockItem *sourceItem, DockItem *targetItem);

--- a/frame/window/mainwindow.cpp
+++ b/frame/window/mainwindow.cpp
@@ -336,6 +336,7 @@ void MainWindow::initConnections()
     connect(DockItemManager::instance(), &DockItemManager::itemInserted, m_mainPanel, &MainPanelControl::insertItem, Qt::DirectConnection);
     connect(DockItemManager::instance(), &DockItemManager::itemRemoved, m_mainPanel, &MainPanelControl::removeItem, Qt::DirectConnection);
     connect(DockItemManager::instance(), &DockItemManager::itemUpdated, m_mainPanel, &MainPanelControl::itemUpdated, Qt::DirectConnection);
+    connect(DockItemManager::instance(), &DockItemManager::requestUpdateItemMinimizedGeometry, m_mainPanel, &MainPanelControl::setKwinAppItemMinimizedGeometry);
     connect(DockItemManager::instance(), &DockItemManager::trayVisableCountChanged, this, &MainWindow::resizeDockIcon, Qt::QueuedConnection);
     connect(DockItemManager::instance(), &DockItemManager::requestWindowAutoHide, m_menuWorker, &MenuWorker::setAutoHide);
     connect(m_mainPanel, &MainPanelControl::itemMoved, DockItemManager::instance(), &DockItemManager::itemMoved, Qt::DirectConnection);


### PR DESCRIPTION
在应用去驻留在任务栏或者驻留的应用在任务栏坐标有变化时，通过wayland协议去设置最小化窗口的位置

Log: 修复wayland下最小化魔灯效果显示异常的问题
Bug: https://pms.uniontech.com/bug-view-111637.html
Influence: wayland下应用窗口最小化显示效果
Change-Id: I56aef594ff0406f5d0bca42f0a4265ffac6398f4