### PR TITLE
fix: 修复插入U盘后导致的崩溃问题

### DIFF
--- a/frame/util/dockpopupwindow.h
+++ b/frame/util/dockpopupwindow.h
@@ -6,10 +6,9 @@
 #define DOCKPOPUPWINDOW_H
 
 #include <darrowrectangle.h>
-#include <dregionmonitor.h>
+#include <DRegionMonitor>
 #include <DWindowManagerHelper>
 
-DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
 class DockPopupWindow : public Dtk::Widget::DArrowRectangle

--- a/plugins/tray/system-trays/systemtrayscontroller.cpp
+++ b/plugins/tray/system-trays/systemtrayscontroller.cpp
@@ -32,7 +32,7 @@ void SystemTraysController::itemAdded(PluginsItemInterface * const itemInter, co
         else {
             emit pluginItemRemoved(itemKey, item);
         }
-    }, Qt::QueuedConnection);
+    });
 
     mPluginsMap[itemInter][itemKey] = item;
 
@@ -69,7 +69,10 @@ void SystemTraysController::itemRemoved(PluginsItemInterface * const itemInter, 
     item->centralWidget()->setParent(nullptr);
 
     // just delete our wrapper object(PluginsItem)
-    item->deleteLater();
+    // 直接删除，item被用到的地方太多，且很多地方没判断是否为空，不应该用deleteLater
+    //    item->deleteLater();
+    delete item;
+    item = nullptr;
 }
 
 void SystemTraysController::requestWindowAutoHide(PluginsItemInterface * const itemInter, const QString &itemKey, const bool autoHide)

--- a/tests/util/ut_dockpopupwindow.cpp
+++ b/tests/util/ut_dockpopupwindow.cpp
@@ -13,7 +13,7 @@
 
 #include <DRegionMonitor>
 
-DWIDGET_USE_NAMESPACE
+DGUI_USE_NAMESPACE
 
 class Test_DockPopupWindow : public QObject, public ::testing::Test
 {


### PR DESCRIPTION
指针异常

Log: 修复插入U盘后导致的崩溃问题
Influence: 反复插拔u盘任务栏崩溃
Bug: https://pms.uniontech.com/bug-view-180075.html
Bug: https://pms.uniontech.com/bug-view-180039.html
Change-Id: I0a6ec7c0c29e782ab5f9a7beaad1288a49072376