### PR TITLE
fix: 解决SNI应用左键弹出菜单后卡死的问题

### DIFF
--- a/plugins/tray/snitraywidget.cpp
+++ b/plugins/tray/snitraywidget.cpp
@@ -108,6 +108,8 @@ SNITrayWidget::SNITrayWidget(const QString &sniServicePath, QWidget *parent)
     connect(m_sniInter, &StatusNotifierItem::OverlayIconPixmapChanged, this, &SNITrayWidget::onSNIOverlayIconPixmapChanged);
     connect(m_sniInter, &StatusNotifierItem::StatusChanged, this, &SNITrayWidget::onSNIStatusChanged);
 
+    connect(this, &SNITrayWidget::requestShowMenu, this, &SNITrayWidget::showContextMenu);
+
     // the following signals can be emit automatically
     // need refresh cached properties in these slots
     connect(m_sniInter, &StatusNotifierItem::NewIcon, [ = ] {
@@ -160,7 +162,7 @@ void SNITrayWidget::sendClick(uint8_t mouseButton, int x, int y)
             // primarily work for apps using libappindicator.
             reply.waitForFinished();
             if (reply.isError()) {
-                showContextMenu(x,y);
+                Q_EMIT requestShowMenu(x, y);
             }
         });
     }

--- a/plugins/tray/snitraywidget.h
+++ b/plugins/tray/snitraywidget.h
@@ -60,6 +60,7 @@ public:
 
 Q_SIGNALS:
     void statusChanged(SNITrayWidget::ItemStatus status);
+    void requestShowMenu(int x, int y);
 
 private Q_SLOTS:
     void initSNIPropertys();


### PR DESCRIPTION
fix: 解决SNI应用左键弹出菜单后卡死的问题

将显示菜单的操作移动到主线程中实现

Log:
Influence: 安装新版QQ，左键点击托盘区的QQ，弹出菜单，观察菜单是否可用
Bug: https://pms.uniontech.com/task-view-233111.html