### PR TITLE
fix: 修复移除蓝牙后弹框依然显示的问题

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -89,6 +89,12 @@ void DockPopupWindow::setContent(QWidget *content)
 void DockPopupWindow::setExtendWidget(QWidget *widget)
 {
     m_extendWidget = widget;
+    connect(widget, &QWidget::destroyed, this, [ this ] { m_extendWidget = nullptr; }, Qt::UniqueConnection);
+}
+
+QWidget *DockPopupWindow::extengWidget() const
+{
+    return m_extendWidget;
 }
 
 void DockPopupWindow::show(const QPoint &pos, const bool model)

--- a/frame/util/dockpopupwindow.h
+++ b/frame/util/dockpopupwindow.h
@@ -45,6 +45,7 @@ public:
 
     void setContent(QWidget *content);
     void setExtendWidget(QWidget *widget);
+    QWidget *extengWidget() const;
 
 public slots:
     void show(const QPoint &pos, const bool model = false);
@@ -82,4 +83,22 @@ private:
     QWidget *m_extendWidget;
 };
 
-class PopupSwitchWidget : pu
+class PopupSwitchWidget : public QWidget
+{
+    Q_OBJECT
+
+public:
+    explicit PopupSwitchWidget(QWidget *parent = nullptr);
+    ~PopupSwitchWidget();
+
+    void pushWidget(QWidget *widget);
+
+protected:
+    bool eventFilter(QObject *watched, QEvent *event) override;
+
+private:
+    QVBoxLayout *m_containerLayout;
+    QWidget *m_topWidget;
+};
+
+#endif // DOCKPOPUPWINDOW_H

--- a/frame/window/quickpluginwindow.cpp
+++ b/frame/window/quickpluginwindow.cpp
@@ -359,6 +359,12 @@ void QuickPluginWindow::onRequestUpdate()
             // 如果该插件在任务栏上，则先将其添加到临时列表中
             pluginItems[dockItem->pluginItem()] = dockItem;
         } else {
+            DockPopupWindow *popupWindow = getPopWindow();
+            if (popupWindow->isVisible()) {
+                // 该插件被移除的情况下，判断弹出窗口是否在当前的插件中打开的，如果是，则隐藏该窗口
+                if (popupWindow->extengWidget() == dockItem)
+                    popupWindow->hide();
+            }
             // 如果该插件不在任务栏上，则先删除
             dockItem->deleteLater();
             countChanged = true;
@@ -864,16 +870,4 @@ void QuickDockItem::showEvent(QShowEvent *event)
     QWidget *itemWidget = m_pluginItem->itemWidget(m_itemKey);
     if (itemWidget && m_mainLayout->indexOf(itemWidget) < 0) {
         itemWidget->show();
-        itemWidget->setFixedSize(suitableSize());
-        m_mainLayout->addWidget(itemWidget);
-    }
-}
-
-void QuickDockItem::hideEvent(QHideEvent *event)
-{
-    if (!m_mainLayout)
-        return QWidget::hideEvent(event);
-
-    QWidget *itemWidget = m_pluginItem->itemWidget(m_itemKey);
-    if (itemWidget && m_mainLayout->indexOf(itemWidget) >= 0) {
-        itemWidget->setParent(m_dockItem
+        itemWidget->setFixedS

--- a/plugins/bluetooth/bluetoothplugin.cpp
+++ b/plugins/bluetooth/bluetoothplugin.cpp
@@ -64,6 +64,8 @@ void BluetoothPlugin::init(PluginProxyInterface *proxyInter)
         m_proxyInter->itemAdded(this, BLUETOOTH_KEY);
     });
     connect(m_bluetoothItem.data(), &BluetoothItem::noAdapter, [&] {
+        m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
+        m_proxyInter->requestSetAppletVisible(this, BLUETOOTH_KEY, false);
         m_proxyInter->itemRemoved(this, BLUETOOTH_KEY);
     });
     connect(m_bluetoothWidget.data(), &BluetoothMainWidget::requestExpand, this, [ = ] {
@@ -162,12 +164,4 @@ QIcon BluetoothPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Col
 PluginsItemInterface::PluginMode BluetoothPlugin::status() const
 {
     if (m_bluetoothItem.data()->isPowered())
-        return PluginMode::Active;
-
-    return PluginMode::Deactive;
-}
-
-QString BluetoothPlugin::description() const
-{
-    if (m_bluetoothItem.data()->isPowered())
-        r
+        return PluginM


### PR DESCRIPTION
移除设备后弹窗不再显示

Log:
Influence: 点击任务栏的蓝牙图标，弹出蓝牙弹窗，然后移除蓝牙，观察蓝牙的弹窗是否存在
Bug: https://pms.uniontech.com/bug-view-181945.html