### PR TITLE
fix: 修复高缩放率下固定区域图标和回收站图标显示异常的问题

### DIFF
--- a/frame/util/imageutil.cpp
+++ b/frame/util/imageutil.cpp
@@ -47,7 +47,9 @@ const QPixmap ImageUtil::loadSvg(const QString &iconName, const QString &localPa
     if (!icon.isNull()) {
         QPixmap pixmap = icon.pixmap(pixmapSize);
         pixmap.setDevicePixelRatio(ratio);
-        return pixmap;
+        if (ratio == 1)
+            return pixmap;
+        return pixmap.scaled(size * ratio, size * ratio);
     }
 
     QPixmap pixmap(pixmapSize, pixmapSize);
@@ -61,7 +63,10 @@ const QPixmap ImageUtil::loadSvg(const QString &iconName, const QString &localPa
     painter.end();
     pixmap.setDevicePixelRatio(ratio);
 
-    return pixmap;
+    if (ratio == 1)
+        return pixmap;
+
+    return pixmap.scaled(size * ratio, size * ratio);
 }
 
 const QPixmap ImageUtil::loadSvg(const QString &iconName, const QSize size, const qreal ratio)
@@ -70,6 +75,14 @@ const QPixmap ImageUtil::loadSvg(const QString &iconName, const QSize size, cons
     if (!icon.isNull()) {
         QPixmap pixmap = icon.pixmap(QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : QSize(size * ratio));
         pixmap.setDevicePixelRatio(ratio);
+        if (ratio == 1)
+            return pixmap;
+
+        if (pixmap.size().width() > size.width() * ratio)
+            pixmap = pixmap.scaledToWidth(size.width() * ratio);
+        if (pixmap.size().height() > size.height() * ratio)
+            pixmap = pixmap.scaledToHeight(size.height() * ratio);
+
         return pixmap;
     }
     return QPixmap();

--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -169,5 +169,4 @@ PluginsItemInterface::PluginType MultitaskingPlugin::type()
 
 PluginFlags MultitaskingPlugin::flags() const
 {
-    return PluginFlag::Type_Fixed;
-}
+    return PluginFlag::Type_Fixed | P

--- a/plugins/show-desktop/showdesktopplugin.cpp
+++ b/plugins/show-desktop/showdesktopplugin.cpp
@@ -166,7 +166,7 @@ PluginsItemInterface::PluginType ShowDesktopPlugin::type()
 
 PluginFlags ShowDesktopPlugin::flags() const
 {
-    return PluginFlag::Type_Fixed;
+    return PluginFlag::Type_Fixed | PluginFlag::Attribute_ForceDock;
 }
 
 void ShowDesktopPlugin::updateVisible()
@@ -201,6 +201,3 @@ void ShowDesktopPlugin::refreshPluginItemsVisible()
             loadPlugin();
             return;
         }
-        updateVisible();
-    }
-}

--- a/plugins/trash/trashwidget.cpp
+++ b/plugins/trash/trashwidget.cpp
@@ -221,6 +221,7 @@ void TrashWidget::updateIcon()
     int pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : int(size * ratio);
     m_icon = icon.pixmap(pixmapSize, pixmapSize);
     m_icon.setDevicePixelRatio(ratio);
+    m_icon = m_icon.scaled(pixmapSize * ratio, pixmapSize * ratio);
 }
 
 void TrashWidget::updateIconAndRefresh()
@@ -254,7 +255,4 @@ void TrashWidget::moveToTrash(const QUrl &url)
     const QFileInfo info = url.toLocalFile();
 
     QStringList argumentList;
-    argumentList << info.absoluteFilePath();
-
-    m_fileManagerInter->Trash(argumentList);
-}
+    argumentList << info.


### PR DESCRIPTION
图标加载后，需要将图标缩放成合适的大小

Log: 修复高缩放率下图标显示异常
Influence: 1.25倍缩放率下，选择非默认主题，观察任务栏显示桌面、多任务试图和回收站的图标大小是否正常
Bug: https://pms.uniontech.com/bug-view-182673.html