### PR TITLE
fix: 修复高缩放率下插件图标显示异常的问题

### DIFF
--- a/frame/window/quickpluginwindow.cpp
+++ b/frame/window/quickpluginwindow.cpp
@@ -839,18 +839,10 @@ void QuickDockItem::paintEvent(QPaintEvent *event)
 
     QSize size = pixmap.size();
     QRect pixmapRect = QRect(QPoint((rect().width() - size.width()) / 2, (rect().height() - size.height()) / 2), pixmap.size());
+    pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
 
-    painter.drawPixmap(pixmapRect, pixmap);
-}
-
-void QuickDockItem::mousePressEvent(QMouseEvent *event)
-{
-    if (event->button() != Qt::RightButton)
-        return QWidget::mousePressEvent(event);
-
-    if (m_contextMenu->actions().isEmpty()) {
-        const QString menuJson = m_pluginItem->itemContextMenu(m_itemKey);
-        if (menuJson.isEmpty())
-            return;
-
-        QJsonDocument js
+    if (m_pluginItem->pluginSizePolicy() == PluginsItemInterface::PluginSizePolicy::System) {
+        size = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size / qApp->devicePixelRatio(): size;
+        pixmapRect = QRect(QPoint((rect().width() - size.width()) / 2, (rect().height() - size.height()) / 2), size);
+    }
+    pa

--- a/plugins/onboard/onboarditem.cpp
+++ b/plugins/onboard/onboarditem.cpp
@@ -116,6 +116,7 @@ const QPixmap OnboardItem::loadSvg(const QString &fileName, const QSize &size) c
     QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size : (size * ratio);
     QPixmap pixmap = QIcon::fromTheme(fileName, m_icon).pixmap(pixmapSize);
     pixmap.setDevicePixelRatio(ratio);
+    pixmap = pixmap.scaled(size * ratio);
 
     return pixmap;
 }
@@ -150,7 +151,4 @@ void OnboardItem::leaveEvent(QEvent *event)
     m_pressed = false;
     update();
 
-    QWidget::leaveEvent(event);
-}
-
-void OnboardItem::resizeEve
+    QWidget::leaveEv

--- a/plugins/pluginmanager/iconmanager.cpp
+++ b/plugins/pluginmanager/iconmanager.cpp
@@ -87,32 +87,32 @@ QPixmap IconManager::pixmap(DGuiApplicationHelper::ColorType colorType) const
     // 组合图标
     QPixmap pixmap;
     if (m_position == Dock::Position::Top || m_position == Dock::Position::Bottom) {
-        if (m_displayMode == Dock::DisplayMode::Efficient) {
-            // 高效模式下，高度固定为30,圆角固定为8
-            pixmap = QPixmap(ITEMWIDTH * plugins.size() + ITEMSPACE * (plugins.size() + 1), 30);
-        } else {
-            // 时尚模式下，高度随着任务栏的大小变化而变化
-            pixmap = QPixmap(ITEMWIDTH * plugins.size() + ITEMSPACE * (plugins.size() + 1), m_size.height() - 8);
-        }
-    } else {
-        if (m_displayMode == Dock::DisplayMode::Efficient) {
-            // 高校模式下，宽度固定
-            pixmap = QPixmap(30, ITEMWIDTH * plugins.size() + ITEMSPACE * (plugins.size() + 1));
-        } else {
-            pixmap = QPixmap(m_size.width() - 8, ITEMWIDTH * plugins.size() + ITEMSPACE * (plugins.size() + 1));
-        }
-    }
-
-    pixmap.fill(Qt::transparent);
-    QPainter painter(&pixmap);
-    painter.setRenderHints(QPainter::SmoothPixmapTransform | QPainter::Antialiasing);
-    if (m_position == Dock::Position::Top || m_position == Dock::Position::Bottom) {
-        QPoint pointPixmap(ITEMSPACE, (pixmap.height() - ITEMHEIGHT) / 2);
+        // 高效模式下，高度固定为30, 时尚模式下，高度随着任务栏的大小变化而变化
+        int iconHeight = (m_displayMode == Dock::DisplayMode::Efficient ? 30 : m_size.height() - 8);
+        int iconWidth = ITEMSPACE;
         for (PluginsItemInterface *plugin : plugins) {
             QIcon icon = plugin->icon(DockPart::QuickShow);
-             QPixmap pixmapDraw = icon.pixmap(ITEMHEIGHT, ITEMHEIGHT);
-             painter.drawPixmap(pointPixmap, pixmapDraw);
-             pointPixmap.setX(pointPixmap.x() + ITEMWIDTH + ITEMSPACE);
-         }
-     } else {
-         QPoint pointP
+            QSize iconSize(ITEMWIDTH, ITEMHEIGHT);
+            QList<QSize> iconSizes = icon.availableSizes();
+            if (iconSizes.size() > 0)
+                iconSize = iconSizes.first() / qApp->devicePixelRatio();
+            iconWidth += iconSize.width() + ITEMSPACE;
+        }
+        iconWidth += ITEMSPACE;
+        pixmap = QPixmap(iconWidth, iconHeight);
+    } else {
+        // 左右方向，高效模式下，宽度固定为30，时尚模式下，宽度随任务栏的大小变化而变化
+        int iconWidth = m_displayMode == Dock::DisplayMode::Efficient ? 30 : m_size.width() - 8;
+        int iconHeight = ITEMHEIGHT;
+        for (PluginsItemInterface *plugin : plugins) {
+            QIcon icon = plugin->icon(DockPart::QuickShow);
+            QSize iconSize(ITEMWIDTH, ITEMHEIGHT);
+            QList<QSize> iconSizes = icon.availableSizes();
+            if (iconSizes.size() > 0)
+                iconSize = iconSizes.first() / qApp->devicePixelRatio();
+            iconHeight += iconSize.height() + ITEMSPACE;
+        }
+        pixmap = QPixmap(iconWidth, iconHeight);
+    }
+
+    pixmap.fill(Qt::t

--- a/plugins/sound/soundwidget.cpp
+++ b/plugins/sound/soundwidget.cpp
@@ -40,7 +40,7 @@
 
 DGUI_USE_NAMESPACE
 
-#define ICON_SIZE 24
+#define ICON_SIZE 18
 #define BACKSIZE 36
 
 SoundWidget::SoundWidget(QWidget *parent)
@@ -68,7 +68,7 @@ void SoundWidget::initUi()
 
     QPixmap leftPixmap = ImageUtil::loadSvg(leftIcon(), QSize(ICON_SIZE, ICON_SIZE));
     QPixmap rightPixmap = ImageUtil::loadSvg(rightIcon(), QSize(ICON_SIZE, ICON_SIZE));
-    m_sliderContainer->setIcon(SliderContainer::IconPosition::LeftIcon, leftPixmap, QSize(), 12);
+    m_sliderContainer->setIcon(SliderContainer::IconPosition::LeftIcon, leftPixmap, QSize(), 10);
     m_sliderContainer->setIcon(SliderContainer::IconPosition::RightIcon, rightPixmap, QSize(BACKSIZE, BACKSIZE), 12);
     m_sliderContainer->setRange(0, std::round(m_dbusAudio->maxUIVolume() * 100.00));
     m_sliderContainer->setPageStep(2);
@@ -127,14 +127,14 @@ const QString SoundWidget::leftIcon()
 {
     const bool mute = existActiveOutputDevice() ? m_defaultSink->mute() : true;
     if (mute)
-        return QString(":/icons/resources/audio-volume-muted-dark");
+        return QString(":/icons/resources/audio-volume-muted-dark.svg");
 
-    return QString(":/icons/resources/volume");
+    return QString(":/icons/resources/volume.svg");
 }
 
 const QString SoundWidget::rightIcon()
 {
-    return QString(":/icons/resources/broadcast");
+    return QString(":/icons/resources/broadcast.svg");
 }
 
 /** 判断是否存在未禁用的声音输出设备
@@ -158,5 +158,4 @@ bool SoundWidget::existActiveOutputDevice() const
         }
     }
 
-    return false;
-}
+    retu


### PR DESCRIPTION
高缩放率下，需要将图标按照缩放下的图标进行显示

Log: 优化高缩放率下插件图标显示异常
Influence: 高分屏，设置缩放率为最高，观察任务栏插件区域的图标显示是否正常
Bug: https://pms.uniontech.com/bug-view-183543.html