### PR TITLE
fix: 修复展开托盘无法通过菜单移除U盘的问题

### DIFF
--- a/frame/window/tray/tray_delegate.cpp
+++ b/frame/window/tray/tray_delegate.cpp
@@ -112,7 +112,9 @@ QWidget *TrayDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem 
         PluginsItemInterface *pluginInter = (PluginsItemInterface *)(index.data(TrayModel::PluginInterfaceRole).toULongLong());
         if (pluginInter) {
             const QString itemKey = QuickSettingController::instance()->itemKey(pluginInter);
-            trayWidget = new SystemPluginItem(pluginInter, itemKey, parent);
+            SystemPluginItem *trayItem = new SystemPluginItem(pluginInter, itemKey, parent);
+            connect(trayItem, &SystemPluginItem::execActionFinished, this, &TrayDelegate::requestHide);
+            trayWidget = trayItem;
         }
     }
 
@@ -222,6 +224,4 @@ void TrayDelegate::paint(QPainter *painter, const QStyleOptionViewItem &option, 
         painter->setPen(borderColor);
         painter->drawPath(path);
     } else {
-        // 如果是任务栏上面的托盘图标，则绘制背景色
-        int borderRadius = 8;
-        if (qApp->property(PROP_DISPLAY_MODE).value<Dock::DisplayMode>() == Dock::DisplayMode::Fashion) 
+        // 如果是任务栏上面的托盘图标�

--- a/frame/window/tray/tray_delegate.h
+++ b/frame/window/tray/tray_delegate.h
@@ -45,6 +45,7 @@ public:
 Q_SIGNALS:
     void removeRow(const QModelIndex &) const;
     void requestDrag(bool) const;
+    void requestHide();
 
 private Q_SLOTS:
     void onUpdateExpand(bool on);
@@ -65,4 +66,4 @@ private:
     QListView *m_listView;
 };
 
-#endif // TRAYDELEGATE_H
+#

--- a/frame/window/tray/tray_gridview.h
+++ b/frame/window/tray/tray_gridview.h
@@ -54,6 +54,7 @@ Q_SIGNALS:
     void dragLeaved();
     void dragEntered();
     void dragFinished();
+    void requestHide();
 
 private Q_SLOTS:
     void clearDragModelIndex();
@@ -90,6 +91,4 @@ private:
     bool m_pressed;
     bool m_aniRunning;
     Dock::Position m_positon;
-};
-
-#endif // GRIDVIEW_H
+}

--- a/frame/window/tray/widgets/systempluginitem.h
+++ b/frame/window/tray/widgets/systempluginitem.h
@@ -62,9 +62,11 @@ public:
 
     void showPopupApplet(QWidget * const applet);
     void hidePopup();
+    bool containsPoint(QPoint pos);
 
 signals:
     void itemVisibleChanged(bool visible);
+    void execActionFinished();
 
 protected:
     bool event(QEvent *event) override;
@@ -116,7 +118,3 @@ private:
 
     static Dock::Position DockPosition;
     static QPointer<DockPopupWindow> PopupWindow;
-    const QGSettings* m_gsettings;
-};
-
-#endif // SYSTEMTRAYITEM_H

--- a/plugins/pluginmanager/dockplugincontroller.cpp
+++ b/plugins/pluginmanager/dockplugincontroller.cpp
@@ -661,10 +661,13 @@ bool DockPluginController::eventFilter(QObject *object, QEvent *event)
 
 bool DockPluginController::pluginCanDock(PluginsItemInterface *plugin) const
 {
-    // 观察插件是否已经驻留在任务栏上，如果已经驻留在任务栏，则始终显示
-    if (plugin->flags() & PluginFlag::Attribute_ForceDock)
+    // 1、如果插件是强制驻留任务栏，则始终显示
+    // 2、如果插件是托盘插件，例如U盘插件，则始终显示
+    if ((plugin->flags() & PluginFlag::Attribute_ForceDock)
+            || (plugin->flags() & PluginFlag::Type_Tray))
         return true;
 
+    // 3、插件已经驻留在任务栏，则始终显示
     const QStringList configPlugins = SETTINGCONFIG->value(DOCK_QUICK_PLUGINS).toStringList();
     return configPlugins.contains(plugin->pluginName());
 }
@@ -695,10 +698,4 @@ void DockPluginController::onConfigChanged(const QString &key, const QVariant &v
             addPluginItem(plugin, itemKey);
             // 只有工具插件是通过QWidget的方式进行显示的，因此，这里只处理工具插件
             if (plugin->flags() & PluginFlag::Type_Tool) {
-                QWidget *itemWidget = plugin->itemWidget(itemKey);
-                if (itemWidget)
-                    itemWidget->setVisible(true);
-            }
-        }
-    }
-}
+                QWidget 


### PR DESCRIPTION
原因：在鼠标点击托盘内右键菜单的时候，会隐藏托盘，导致菜单跟着隐藏，结果是菜单的相关功能不生效
解决方案：在点击托盘区域的时候，判断鼠标位置是否在托盘区域内，包括菜单区域，如果在托盘区域内，则不关闭托盘，等菜单点击完成后再关闭

Log: 修复托盘U盘图标右键不生效的问题
Influence: 插入U盘，打开托盘区，右键菜单，点击，观察功能是否生效
Bug: https://pms.uniontech.com/bug-view-182299.html