### PR TITLE
fix: 修复图标异常问题

### DIFF
--- a/configs/com.deepin.dde.dock.dconfig.json
+++ b/configs/com.deepin.dde.dock.dconfig.json
@@ -27,14 +27,11 @@
 			"visibility": "private"
 		},
 		"Dock_Quick_Tray_Name": {
-			"value": ["fcitx"],
+			"value": ["fcitx", "indicator:keybord_layout"],
 			"serial": 0,
 			"flags": [],
 			"name": "显示在任务栏上的托盘图标",
 			"name[zh_CN]": "任务栏上固定的托盘图标",
 			"description": "记录哪些托盘的图标在任务栏启动的时候显示在任务栏上",
 			"permissions": "readwrite",
-			"visibility": "private"
-		}
-    }
-}
+			"visibi

--- a/frame/window/quickpluginwindow.cpp
+++ b/frame/window/quickpluginwindow.cpp
@@ -837,12 +837,17 @@ void QuickDockItem::paintEvent(QPaintEvent *event)
     if (pixmap.isNull())
         return QWidget::paintEvent(event);
 
-    QSize size = pixmap.size();
-    QRect pixmapRect = QRect(QPoint((rect().width() - size.width()) / 2, (rect().height() - size.height()) / 2), pixmap.size());
     pixmap.setDevicePixelRatio(qApp->devicePixelRatio());
 
-    if (m_pluginItem->pluginSizePolicy() == PluginsItemInterface::PluginSizePolicy::System) {
-        size = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? size / qApp->devicePixelRatio(): size;
-        pixmapRect = QRect(QPoint((rect().width() - size.width()) / 2, (rect().height() - size.height()) / 2), size);
-    }
-    pa
+    QSize size = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? pixmap.size() / qApp->devicePixelRatio(): pixmap.size();
+    QRect pixmapRect = QRect(QPoint((rect().width() - size.width()) / 2, (rect().height() - size.height()) / 2), size);
+    painter.drawPixmap(pixmapRect, pixmap);
+}
+
+void QuickDockItem::mousePressEvent(QMouseEvent *event)
+{
+    if (event->button() != Qt::RightButton)
+        return QWidget::mousePressEvent(event);
+
+    if (m_contextMenu->actions().isEmpty()) {
+ 

--- a/plugins/bluetooth/bluetoothmainwidget.cpp
+++ b/plugins/bluetooth/bluetoothmainwidget.cpp
@@ -42,6 +42,7 @@ BluetoothMainWidget::BluetoothMainWidget(AdaptersManager *adapterManager, QWidge
     , m_nameLabel(new QLabel(this))
     , m_stateLabel(new QLabel(this))
     , m_expandLabel(new QLabel(this))
+    , m_mouseEnter(false)
 {
     initUi();
     initConnection();
@@ -66,8 +67,11 @@ bool BluetoothMainWidget::eventFilter(QObject *watcher, QEvent *event)
             QPainterPath path;
             path.addEllipse(ptCenter, size / 2 - 1, size / 2 - 1);
             // 设置黑色背景色
-            QColor backColor(Qt::black);
-            backColor.setAlphaF(0.1);
+            QColor backColor = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType ? Qt::black : Qt::white);
+            if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType)
+                backColor.setAlphaF(m_mouseEnter ? 0.2 : 0.1);
+            else
+                backColor.setAlphaF(m_mouseEnter ? 0.1 : 0.2);
             painter.setBrush(backColor);
             painter.fillPath(path, backColor);
             // 添加图标
@@ -80,6 +84,16 @@ bool BluetoothMainWidget::eventFilter(QObject *watcher, QEvent *event)
             }
             painter.drawPixmap(QPoint(ptCenter.x() - pixmap.size().width() / 2, ptCenter.y() - pixmap.size().height() / 2), pixmap);
             return true;
+        }
+        case QEvent::Enter: {
+            m_mouseEnter = true;
+            m_iconWidget->update();
+            break;
+        }
+        case QEvent::Leave: {
+            m_mouseEnter = false;
+            m_iconWidget->update();
+            break;
         }
         case QEvent::MouseButtonRelease: {
             bool status = !(isOpen());
@@ -115,10 +129,7 @@ void BluetoothMainWidget::initUi()
     QFont nameFont = DFontSizeManager::instance()->t6();
     nameFont.setBold(true);
 
-    QPalette pe;
-    pe.setColor(QPalette::WindowText, Qt::black);
     m_nameLabel->setParent(textWidget);
-    m_nameLabel->setPalette(pe);
     m_nameLabel->setFont(nameFont);
 
     m_stateLabel->setParent(textWidget);
@@ -182,17 +193,4 @@ bool BluetoothMainWidget::isOpen() const
     return false;
 }
 
-QString BluetoothMainWidget::bluetoothIcon(bool isOpen) const
-{
-    if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType)
-        return isOpen ? ":/bluetooth-active-symbolic-dark.svg" : ":/bluetooth-disable-symbolic-dark.svg";
-
-    return isOpen ? ":/bluetooth-active-symbolic.svg" : ":/bluetooth-disable-symbolic.svg";
-}
-
-void BluetoothMainWidget::onAdapterChanged()
-{
-    bool bluetoothIsOpen = isOpen();
-    m_stateLabel->setText(bluetoothIsOpen ? tr("Turn on") : tr("Turn off"));
-    m_iconWidget->update();
-}
+QString BluetoothMainWidget::bluetoothIcon(bool is

--- a/plugins/bluetooth/bluetoothmainwidget.h
+++ b/plugins/bluetooth/bluetoothmainwidget.h
@@ -59,6 +59,7 @@ private:
     QLabel *m_nameLabel;
     QLabel *m_stateLabel;
     QLabel *m_expandLabel;
+    bool m_mouseEnter;
 };
 
-#endif // BLUETOOTHMAINWIDGET_H
+#endif //

--- a/plugins/pluginmanager/dockplugincontroller.h
+++ b/plugins/pluginmanager/dockplugincontroller.h
@@ -69,6 +69,7 @@ protected:
     bool eventFilter(QObject *object, QEvent *event) override;
 
     bool pluginCanDock(PluginsItemInterface *plugin) const;
+    bool pluginCanDock(const QStringList &config, PluginsItemInterface *plugin) const;
     void updateDockInfo(PluginsItemInterface * const itemInter, const DockPart &part) override;
 
 private:
@@ -108,9 +109,4 @@ private:
     QMap<QPair<QString, PluginsItemInterface *>, bool> m_pluginLoadMap;
 
     QJsonObject m_pluginSettingsObject;
-    QMap<qulonglong, PluginAdapter *> m_pluginAdapterMap;
-
-    PluginProxyInterface *m_proxyInter;
-};
-
-#endif // ABSTRACTPLUGINSCONTROLLER_H
+    QMap<qulonglong, PluginAdapter *> m_pluginAdapterM

--- a/plugins/pluginmanager/iconmanager.cpp
+++ b/plugins/pluginmanager/iconmanager.cpp
@@ -33,6 +33,8 @@
 #define ITEMSPACE 6
 #define ITEMHEIGHT 16
 #define ITEMWIDTH 18
+#define MINISIZE 1
+#define STARTPOS 2
 
 static QStringList pluginNames = {"power", "sound", "network"};
 
@@ -84,35 +86,34 @@ QPixmap IconManager::pixmap(DGuiApplicationHelper::ColorType colorType) const
         return pixmap;
     }
 
+    int itemSpace = 0;
+    if (m_position == Dock::Position::Top || m_position == Dock::Position::Bottom)
+        itemSpace = (m_displayMode == Dock::DisplayMode::Efficient ? 8 : 10);
+    else
+        itemSpace = 2;
     // 组合图标
     QPixmap pixmap;
     if (m_position == Dock::Position::Top || m_position == Dock::Position::Bottom) {
         // 高效模式下，高度固定为30, 时尚模式下，高度随着任务栏的大小变化而变化
         int iconHeight = (m_displayMode == Dock::DisplayMode::Efficient ? 30 : m_size.height() - 8);
-        int iconWidth = ITEMSPACE;
+        if (iconHeight <= 0)
+            iconHeight = MINISIZE;
+        int iconWidth = STARTPOS;
         for (PluginsItemInterface *plugin : plugins) {
             QIcon icon = plugin->icon(DockPart::QuickShow);
-            QSize iconSize(ITEMWIDTH, ITEMHEIGHT);
+            QSize iconSize = QSize(ITEMWIDTH, ITEMHEIGHT) * qApp->devicePixelRatio();
             QList<QSize> iconSizes = icon.availableSizes();
             if (iconSizes.size() > 0)
-                iconSize = iconSizes.first() / qApp->devicePixelRatio();
-            iconWidth += iconSize.width() + ITEMSPACE;
+                iconSize = iconSizes.first();
+            iconWidth += iconSize.width();
         }
-        iconWidth += ITEMSPACE;
+        iconWidth += itemSpace * (plugins.size() - 1);
         pixmap = QPixmap(iconWidth, iconHeight);
     } else {
         // 左右方向，高效模式下，宽度固定为30，时尚模式下，宽度随任务栏的大小变化而变化
         int iconWidth = m_displayMode == Dock::DisplayMode::Efficient ? 30 : m_size.width() - 8;
-        int iconHeight = ITEMHEIGHT;
+        if (iconWidth <= 0)
+            iconWidth = MINISIZE;
+        int iconHeight = STARTPOS;
         for (PluginsItemInterface *plugin : plugins) {
-            QIcon icon = plugin->icon(DockPart::QuickShow);
-            QSize iconSize(ITEMWIDTH, ITEMHEIGHT);
-            QList<QSize> iconSizes = icon.availableSizes();
-            if (iconSizes.size() > 0)
-                iconSize = iconSizes.first() / qApp->devicePixelRatio();
-            iconHeight += iconSize.height() + ITEMSPACE;
-        }
-        pixmap = QPixmap(iconWidth, iconHeight);
-    }
-
-    pixmap.fill(Qt::t
+            QIcon icon = plugi


### PR DESCRIPTION
1、修复拖动过程中组合图标尺寸显示异常的问题
2、修复从控制中心设置插件显示隐藏引起的异常问题
3、修复高缩放率下的组合图标显示异常问题
4、修复蓝牙面板在不同的主题下颜色的显示的问题
5、社区版键盘布局默认在任务栏显示

Log: 修复图标显示的问题
Influence: 高缩放率下，观察组合图标显示是否正常
Bug: https://pms.uniontech.com/bug-view-181723.html