### PR TITLE
fix: 修复快捷面板插件子面板无法关闭主面板的问题

### DIFF
--- a/plugins/bluetooth/bluetoothitem.cpp
+++ b/plugins/bluetooth/bluetoothitem.cpp
@@ -67,6 +67,7 @@ BluetoothItem::BluetoothItem(AdaptersManager *adapterManager, QWidget *parent)
     connect(DGuiApplicationHelper::instance(), &DGuiApplicationHelper::themeTypeChanged, this, &BluetoothItem::refreshIcon);
     connect(m_applet, &BluetoothApplet::noAdapter, this, &BluetoothItem::noAdapter);
     connect(m_applet, &BluetoothApplet::justHasAdapter, this, &BluetoothItem::justHasAdapter);
+    connect(m_applet, &BluetoothApplet::requestHide, this, &BluetoothItem::requestHide);
 }
 
 QWidget *BluetoothItem::tipsWidget()
@@ -224,5 +225,4 @@ void BluetoothItem::paintEvent(QPaintEvent *event)
     QPainter painter(this);
     const QRectF &rf = QRectF(rect());
     const QRectF &rfp = QRectF(m_iconPixmap.rect());
-    painter.drawPixmap(rf.center() - rfp.center() / m_iconPixmap.devicePixelRatioF(), m_iconPixmap);
-}
+    painter.dr

--- a/plugins/bluetooth/bluetoothitem.h
+++ b/plugins/bluetooth/bluetoothitem.h
@@ -62,6 +62,7 @@ signals:
     void requestContextMenu() const;
     void noAdapter();
     void justHasAdapter();
+    void requestHide();
 
 private:
     Dock::TipsWidget *m_tipsLabel;
@@ -72,4 +73,4 @@ private:
     bool m_adapterPowered;
 };
 
-#endif // BLUETOOTHITEM_H
+#e

--- a/plugins/bluetooth/bluetoothplugin.cpp
+++ b/plugins/bluetooth/bluetoothplugin.cpp
@@ -60,15 +60,18 @@ void BluetoothPlugin::init(PluginProxyInterface *proxyInter)
 
     m_bluetoothWidget.reset(new BluetoothMainWidget(m_adapterManager));
 
-    connect(m_bluetoothItem.data(), &BluetoothItem::justHasAdapter, [&] {
+    connect(m_bluetoothItem.data(), &BluetoothItem::justHasAdapter, [ this ] {
         m_proxyInter->itemAdded(this, BLUETOOTH_KEY);
     });
-    connect(m_bluetoothItem.data(), &BluetoothItem::noAdapter, [&] {
+    connect(m_bluetoothItem.data(), &BluetoothItem::requestHide, [ this ] {
+        m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
+    });
+    connect(m_bluetoothItem.data(), &BluetoothItem::noAdapter, [ this ] {
         m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
         m_proxyInter->requestSetAppletVisible(this, BLUETOOTH_KEY, false);
         m_proxyInter->itemRemoved(this, BLUETOOTH_KEY);
     });
-    connect(m_bluetoothWidget.data(), &BluetoothMainWidget::requestExpand, this, [ = ] {
+    connect(m_bluetoothWidget.data(), &BluetoothMainWidget::requestExpand, this, [ this ] {
         m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, true);
     });
 
@@ -155,13 +158,4 @@ QIcon BluetoothPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Col
     case DockPart::QuickShow:
         return ImageUtil::loadSvg(iconFile, QSize(18, 16));
     default:
-        break;
-    }
-
-    return QIcon();
-}
-
-PluginsItemInterface::PluginMode BluetoothPlugin::status() const
-{
-    if (m_bluetoothItem.data()->isPowered())
-        return Plugin
+     

--- a/plugins/bluetooth/componments/bluetoothapplet.cpp
+++ b/plugins/bluetooth/componments/bluetoothapplet.cpp
@@ -302,6 +302,7 @@ void BluetoothApplet::initConnect()
         .method(QString("ShowPage"))
         .arg(QString("bluetooth"))
         .call();
+        emit requestHide();
     });
     connect(DApplicationHelper::instance(), &DApplicationHelper::themeTypeChanged, this, &BluetoothApplet::updateIconTheme);
     connect(m_airPlaneModeInter, &DBusAirplaneMode::EnabledChanged, this, &BluetoothApplet::setAirplaneModeEnabled);
@@ -356,6 +357,4 @@ void BluetoothApplet::updateSize()
 
     static const int maxHeight = (TitleHeight + TitleSpace) + MaxDeviceCount * DeviceItemHeight;
 
-    setFixedSize(ItemWidth, qMin(maxHeight, height));
-}
-
+    setFixedSize(ItemWidth, q

--- a/plugins/bluetooth/componments/bluetoothapplet.h
+++ b/plugins/bluetooth/componments/bluetoothapplet.h
@@ -102,6 +102,7 @@ signals:
     void justHasAdapter();
     void powerChanged(bool state);
     void deviceStateChanged(const Device *device);
+    void requestHide();
 
 public slots:
     // 蓝牙适配器增加
@@ -137,4 +138,4 @@ private:
     bool m_airplaneModeEnable;
 };
 
-#endif // BLUETOOTHAPPLET_H
+#end

--- a/plugins/display/displayplugin.cpp
+++ b/plugins/display/displayplugin.cpp
@@ -73,6 +73,9 @@ void DisplayPlugin::init(PluginProxyInterface *proxyInter)
     connect(m_displayWidget.data(), &BrightnessWidget::brightClicked, this, [ this ] {
         m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, true);
     });
+    connect(m_displaySettingWidget.data(), &DisplaySettingWidget::requestHide, this, [ this ] {
+        m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
+    });
     connect(m_model.data(), &BrightnessModel::screenVisibleChanged, this, [ this ](bool visible) {
         if (visible)
             m_proxyInter->itemAdded(this, pluginName());
@@ -99,13 +102,4 @@ QWidget *DisplayPlugin::itemTipsWidget(const QString &itemKey)
 
 QWidget *DisplayPlugin::itemPopupApplet(const QString &itemKey)
 {
-    if (itemKey == QUICK_ITEM_KEY)
-        return m_displaySettingWidget.data();
-
-    return nullptr;
-}
-
-PluginFlags DisplayPlugin::flags() const
-{
-    return PluginFlag::Type_Common | PluginFlag::Quick_Full;
-}
+    if (itemKey == QUICK_ITEM_K

--- a/plugins/display/displaysettingwidget.cpp
+++ b/plugins/display/displaysettingwidget.cpp
@@ -42,7 +42,7 @@ DisplaySettingWidget::DisplaySettingWidget(QWidget *parent)
                 .path("/org/deepin/dde/ControlCenter1")
                 .interface("org.deepin.dde.ControlCenter1")
                 .method("ShowPage").arg(QString("display")).call();
-        hide();
+        Q_EMIT requestHide();
     });
 }
 
@@ -69,5 +69,4 @@ void DisplaySettingWidget::resizeWidgetHeight()
 {
     QMargins margins = this->contentsMargins();
     setFixedHeight(margins.top() + margins.bottom() + m_brightnessAdjWidget->height() +
-                   m_collaborationWidget->height() + m_settingBtn->height() + ItemSpacing * 2);
-}
+                   m_collaborationWidget->height() + m_settingBtn->height() + ItemSp

--- a/plugins/display/displaysettingwidget.h
+++ b/plugins/display/displaysettingwidget.h
@@ -34,8 +34,12 @@ class DevCollaborationWidget;
 class DisplaySettingWidget : public QWidget
 {
     Q_OBJECT
+
 public:
     explicit DisplaySettingWidget(QWidget *parent = nullptr);
+
+Q_SIGNALS:
+    void requestHide();
 
 private:
     void initUI();
@@ -46,6 +50,3 @@ private:
     DevCollaborationWidget *m_collaborationWidget;  // 跨端协同
     QPushButton *m_settingBtn;                      // 设置按钮
 };
-
-
-#endif // DISPLAY_SETTING_WIDGET_H

--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -449,7 +449,7 @@ void SoundDevicesWidget::onSelectIndexChanged(const QModelIndex &index)
                 .path("/org/deepin/dde/ControlCenter1")
                 .interface("org.deepin.dde.ControlCenter1")
                 .method("ShowPage").arg(QString("sound")).call();
-        hide();
+        emit requestHide();
     }
 }
 
@@ -474,5 +474,4 @@ void SoundDevicesWidget::onDefaultSinkChanged(const QDBusObjectPath &value)
     }
 
     resetVolumeInfo();
-    m_deviceList->update();
-}
+    m_deviceList->

--- a/plugins/sound/sounddeviceswidget.h
+++ b/plugins/sound/sounddeviceswidget.h
@@ -53,6 +53,7 @@ public:
 
 Q_SIGNALS:
     void enableChanged(bool);
+    void requestHide();
 
 protected:
     bool eventFilter(QObject *watcher, QEvent *event) override;
@@ -99,4 +100,4 @@ private:
     QList<SoundDevicePort *> m_ports;
 };
 
-#endif // VOLUMEDEVICESWIDGET_H
+#endif /

--- a/plugins/sound/soundplugin.cpp
+++ b/plugins/sound/soundplugin.cpp
@@ -70,6 +70,9 @@ void SoundPlugin::init(PluginProxyInterface *proxyInter)
     }
 
     connect(m_soundDeviceWidget.data(), &SoundDevicesWidget::enableChanged, m_soundWidget.data(), &SoundWidget::setEnabled);
+    connect(m_soundDeviceWidget.data(), &SoundDevicesWidget::requestHide, this, [ this ] {
+        m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
+    });
 }
 
 void SoundPlugin::pluginStateSwitched()
@@ -213,10 +216,3 @@ bool SoundPlugin::eventHandler(QEvent *event)
         // 向上滚动，增大音量
         if (volume < maxVolume)
             sinkDBus.method("SetVolume").arg(qMin(volume + 0.02, maxVolume)).arg(true).call();
-    } else {
-        // 向下滚动，调小音量
-        if (volume > 0)
-            sinkDBus.method("SetVolume").arg(qMax(volume - 0.02, 0.0)).arg(true).call();
-    }
-
-  


### PR DESCRIPTION
在子插件点击相应的功能按钮的时候，调用requestSetAppletVisible方法来隐藏面板

Log: 优化快捷面板插件功能
Influence: 进入快捷面板的蓝牙子界面点击设置，进入声音子界面点击设置，进入亮度调整子界面点击设置，在弹出对应的功能后，观察快捷面板是否隐藏
Task: https://pms.uniontech.com/task-view-222353.html