### PR TITLE
fix: 修复高效模式下无法打开企业微信的问题

### DIFF
--- a/frame/window/tray/widgets/xembedtrayitemwidget.cpp
+++ b/frame/window/tray/widgets/xembedtrayitemwidget.cpp
@@ -124,6 +124,13 @@ void XEmbedTrayItemWidget::showEvent(QShowEvent *e)
 {
     QWidget::showEvent(e);
 
+    xcb_connection_t *connection = IS_WAYLAND_DISPLAY ? m_xcbCnn : QX11Info::connection();
+    if (connection) {
+        xcb_map_window(connection, m_containerWid);
+
+        xcb_reparent_window(connection, m_windowId, m_containerWid, 0, 0);
+    }
+
     m_updateTimer->start();
 }
 
@@ -260,11 +267,13 @@ void XEmbedTrayItemWidget::wrapWindow()
 
     xcb_flush(c);
 
-    xcb_map_window(c, m_containerWid);
+    if (isVisible()) {
+        xcb_map_window(c, m_containerWid);
 
-    xcb_reparent_window(c, m_windowId,
-                        m_containerWid,
-                        0, 0);
+        xcb_reparent_window(c, m_windowId,
+                            m_containerWid,
+                            0, 0);
+    }
 
     /*
      * Render the embedded window offscreen


### PR DESCRIPTION
根因：高效模式和时尚模式分别创建了各自的XEmbedTrayItemWidget对象，时尚模式后创建这个对象，在创建这个对象的构造函数中会把QX11Info::connection与容器的id进行配对组合，导致后创建的对象替换了先创建对象的容器id与QX11Info::connection的映射，在点击先创建对象的时候，无法找到对应的匹配关系，导致无法打开XEmbedTrayItemWidget协议对应的窗口 修改：在构造函数不再创建映射，在当前窗口showEvent事件中再对容器id和QX11Info::connection进行映射，这样在点击窗口图标的时候可以打开正确的窗口

Log: 修复高效模式下无法打开企业微信的问题
Influence: 进入高效模式，打开企业微信和微信等应用，观察是否正常打开窗口
Bug: https://pms.uniontech.com/bug-view-182065.html