### PR TITLE
fix: 点击托盘企业微信图标，无反应

### DIFF
--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -488,6 +488,8 @@ QPoint AppItem::appIconPosition() const
 
 void AppItem::updateWindowInfos(const WindowInfoMap &info)
 {
+    if (info.size() <= 0)
+        return;
     m_windowInfos = info;
     m_currentWindowId = info.firstKey();
     if (m_appPreviewTips)

--- a/plugins/tray/xembedtraywidget.cpp
+++ b/plugins/tray/xembedtraywidget.cpp
@@ -367,7 +367,7 @@ void XEmbedTrayWidget::sendClick(uint8_t mouseButton, int x, int y)
         return;
 
     m_sendHoverEvent->stop();
-    auto c = QX11Info::connection();
+    auto c = IS_WAYLAND_DISPLAY ? m_xcbCnn :QX11Info::connection();
     if (!c) {
         qWarning() << "QX11Info::connection() is " << c;
         return;
@@ -379,7 +379,7 @@ void XEmbedTrayWidget::sendClick(uint8_t mouseButton, int x, int y)
 
     Display *display = IS_WAYLAND_DISPLAY ? m_display : QX11Info::display();
 
-    if (m_injectMode == XTest) {
+    if (m_injectMode == XTest || IS_WAYLAND_DISPLAY) {
         XTestFakeMotionEvent(display, 0, p.x(), p.y(), CurrentTime);
         XFlush(display);
         XTestFakeButtonEvent(display, mouseButton, true, CurrentTime);


### PR DESCRIPTION
sendclick发送消息响应时，没有判断wayland下的情况，直接return。

Log: 修复点击托盘企业微信图标，无反应的问题
Influence: 托盘图标点击的问题
Bug: https://pms.uniontech.com/bug-view-185343.html