### PR TITLE
fix: 任务栏多任务视图不能正常移除

### DIFF
--- a/configs/com.deepin.dde.dock.dconfig.json
+++ b/configs/com.deepin.dde.dock.dconfig.json
@@ -17,7 +17,7 @@
             "visibility":"public"
         },
 		"Dock_Quick_Plugins": {
-                        "value": ["power", "network", "shutdown", "trash"],
+                        "value": ["power", "network", "shutdown", "trash", "show-desktop", "multitasking"],
 			"serial": 0,
 			"flags": [],
 			"name": "显示在任务栏上的快捷插件",

--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -11,7 +11,6 @@
 
 #include <QIcon>
 
-#define PLUGIN_STATE_KEY    "enable"
 DGUI_USE_NAMESPACE
 
 using namespace Dock;
@@ -121,7 +120,7 @@ void MultitaskingPlugin::invokedMenuItem(const QString &itemKey, const QString &
         .arg(1)
         .call();
     } else if (menuId == "remove") {
-        pluginStateSwitched();
+        m_proxyInter->itemRemoved(this, PLUGIN_KEY);
     }
 }
 
@@ -153,5 +152,5 @@ PluginsItemInterface::PluginType MultitaskingPlugin::type()
 
 PluginFlags MultitaskingPlugin::flags() const
 {
-    return PluginFlag::Type_Fixed | PluginFlag::Attribute_ForceDock;
+    return PluginFlag::Type_Fixed | Attribute_CanSetting;
 }

--- a/plugins/show-desktop/showdesktopplugin.h
+++ b/plugins/show-desktop/showdesktopplugin.h
@@ -25,9 +25,7 @@ public:
     const QString pluginName() const override;
     const QString pluginDisplayName() const override;
     void init(PluginProxyInterface *proxyInter) override;
-    void pluginStateSwitched() override;
     bool pluginIsAllowDisable() override { return true; }
-    bool pluginIsDisable() override;
     QWidget *itemWidget(const QString &itemKey) override;
     QWidget *itemTipsWidget(const QString &itemKey) override;
     const QString itemCommand(const QString &itemKey) override;
@@ -36,18 +34,10 @@ public:
     void refreshIcon(const QString &itemKey) override;
     int itemSortKey(const QString &itemKey) override;
     void setSortKey(const QString &itemKey, const int order) override;
-    void pluginSettingsChanged() override;
     PluginType type() override;
     PluginFlags flags() const override;
 
 private:
-    void updateVisible();
-    void loadPlugin();
-    void refreshPluginItemsVisible();
-
-private:
-    bool m_pluginLoaded;
-
     QScopedPointer<ShowDesktopWidget> m_showDesktopWidget;
     QScopedPointer<Dock::TipsWidget> m_tipsLabel;
 };


### PR DESCRIPTION
1.通过任务栏右键移除按钮时，移除对应插件
2.显示桌面和多任务视图需要加入到快捷插件显示中

Log: 修复任务栏多任务视图不能正常移除的问题
Bug: https://github.com/linuxdeepin/developer-center/issues/3599
Influence: 任务栏显示桌面合多任务视图插件的显示