### PR TITLE
fix: 关闭窗口特效后,任务栏托盘窗口出现四个黑角

### DIFF
--- a/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/frame/window/tray/widgets/expandiconwidget.cpp
@@ -177,7 +177,7 @@ TrayGridWidget *ExpandIconWidget::popupTrayView()
 Dock::Position TrayGridWidget::m_position = Dock::Position::Bottom;
 
 TrayGridWidget::TrayGridWidget(QWidget *parent)
-    : QWidget (parent)
+    : DBlurEffectWidget (parent)
     , m_dockInter(new DockInter(dockServiceName(), dockServicePath(), QDBusConnection::sessionBus(), this))
     , m_trayGridView(nullptr)
     , m_referGridView(nullptr)
@@ -241,24 +241,10 @@ void TrayGridWidget::resetPosition()
     move(ptPos);
 }
 
-void TrayGridWidget::paintEvent(QPaintEvent *event)
-{
-    Q_UNUSED(event);
-
-    QPainter painter(this);
-    painter.setRenderHint(QPainter::Antialiasing);
-    QPainterPath path;
-    path.addRoundedRect(rect(), 18, 18);
-    painter.setCompositionMode(QPainter::CompositionMode_Xor);
-    painter.setClipPath(path);
-
-    painter.fillPath(path, maskColor());
-}
-
 void TrayGridWidget::showEvent(QShowEvent *event)
 {
     m_regionInter->registerRegion();
-    QWidget::showEvent(event);
+    DBlurEffectWidget::showEvent(event);
 }
 
 void TrayGridWidget::hideEvent(QHideEvent *event)
@@ -266,7 +252,7 @@ void TrayGridWidget::hideEvent(QHideEvent *event)
     m_regionInter->unregisterRegion();
     // 在当前托盘区域隐藏后，需要设置任务栏区域的展开按钮的托盘为隐藏状态
     TrayModel::getDockModel()->updateOpenExpand(false);
-    QWidget::hideEvent(event);
+    DBlurEffectWidget::hideEvent(event);
 }
 
 void TrayGridWidget::initMember()

--- a/frame/window/tray/widgets/expandiconwidget.h
+++ b/frame/window/tray/widgets/expandiconwidget.h
@@ -10,6 +10,10 @@
 #include "basetraywidget.h"
 #include "dbusutil.h"
 
+#include <DBlurEffectWidget>
+
+DWIDGET_USE_NAMESPACE
+
 class TrayGridView;
 class TrayModel;
 class TrayDelegate;
@@ -43,7 +47,7 @@ private:
 };
 
 // 绘制圆角窗体
-class TrayGridWidget : public QWidget
+class TrayGridWidget : public DBlurEffectWidget
 {
     Q_OBJECT
 
@@ -57,7 +61,6 @@ public:
     void resetPosition();
 
 protected:
-    void paintEvent(QPaintEvent *event) override;
     void showEvent(QShowEvent *event) override;
     void hideEvent(QHideEvent *event) override;
 


### PR DESCRIPTION
任务栏托盘窗口实现采用的是自定义绘制,与窗口特效不兼容,改用继承DBlurEffectWidget类的方式实现窗口

Log: 修改托盘窗口绘制方式
Bug: https://github.com/linuxdeepin/developer-center/issues/3615