### PR TITLE
fix: 控制中心设置的电源选项任务栏未生效

### DIFF
--- a/configs/org.deepin.dde.dock.power.json
+++ b/configs/org.deepin.dde.dock.power.json
@@ -1,0 +1,46 @@
+{
+    "magic": "dsg.config.meta",
+    "version": "1.0",
+    "contents": {
+        "control": {
+            "value": false,
+            "serial": 0,
+            "flags": [],
+            "name": "contorl",
+            "name[zh_CN]": "控制",
+            "description": "阻止鼠标事件",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "enable": {
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "enable",
+            "name[zh_CN]": "使能",
+            "description": "使能电源管理模块。",
+            "permissions": "readwrite",
+            "visibility": "private"
+        },
+        "showtimetofull":{
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "showtimetofull",
+            "name[zh_CN]": "显示完整时间",
+            "description": "是否显示电池使用时间/剩余充电时间。",
+            "permissions": "readwrite",
+            "visibility": "public"
+        },
+        "menu-enable":{
+            "value": true,
+            "serial": 0,
+            "flags": [],
+            "name": "menu-enable",
+            "name[zh_CN]": "使能菜单",
+            "description": "使能菜单。",
+            "permissions": "readwrite",
+            "visibility": "private"
+        }
+    }
+}

--- a/plugins/power/powerplugin.h
+++ b/plugins/power/powerplugin.h
@@ -15,6 +15,11 @@
 #include <QLabel>
 
 using SystemPowerInter = org::deepin::dde::Power1;
+
+DCORE_BEGIN_NAMESPACE
+class DConfig;
+DCORE_END_NAMESPACE
+
 namespace Dock {
 class TipsWidget;
 }
@@ -61,6 +66,7 @@ private:
 
     SystemPowerInter *m_systemPowerInter;
     DBusPower *m_powerInter;
+    Dtk::Core::DConfig *m_dconfig; // 配置
     QTimer *m_preChargeTimer;
     QWidget *m_quickPanel;
     QLabel *m_imageLabel;


### PR DESCRIPTION
任务栏电源配置原来管理gsetting配置替换成dconfig配置

Log: 修复控制中心设置的电源选项任务栏未生效的问题
resolve: https://github.com/linuxdeepin/developer-center/issues/3768
Influence: 任务栏电池信息显示