### PR TITLE
fix: 任务栏时间右键菜单时间格式显示错误

### DIFF
--- a/frame/window/components/datetimedisplayer.cpp
+++ b/frame/window/components/datetimedisplayer.cpp
@@ -353,13 +353,13 @@ QFont DateTimeDisplayer::timeFont() const
 void DateTimeDisplayer::createMenuItem()
 {
     QAction *timeFormatAction = new QAction(this);
-    if (m_timedateInter->use24HourFormat())
-        timeFormatAction->setText(tr("12-hour time"));
-    else
-        timeFormatAction->setText(tr("24-hour time"));
+    m_timedateInter->use24HourFormat() ? timeFormatAction->setText(tr("12-hour time"))
+                                       : timeFormatAction->setText(tr("24-hour time"));
 
     connect(timeFormatAction, &QAction::triggered, this, [ = ] {
         m_timedateInter->setUse24HourFormat(!m_timedateInter->use24HourFormat());
+        m_timedateInter->use24HourFormat() ? timeFormatAction->setText(tr("12-hour time"))
+                                           : timeFormatAction->setText(tr("24-hour time"));
     });
     m_menu->addAction(timeFormatAction);
 


### PR DESCRIPTION
当更改了时间显示格式后，需要更新下menu菜单的显示状态

Log: 修复任务栏时间右键菜单时间格式显示错误的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/3792
Influence: 任务栏时间插件右键菜单