### PR TITLE
fix: AA_EnableHighDpiScaling setted after QGuiApplication constructed.

### DIFF
--- a/frame/main.cpp
+++ b/frame/main.cpp
@@ -158,6 +158,7 @@ int main(int argc, char *argv[])
     }
 
     DGuiApplicationHelper::setAttribute(DGuiApplicationHelper::UseInactiveColorGroup, false);
+    DockApplication::setAttribute(Qt::AA_EnableHighDpiScaling, true);
     DockApplication app(argc, argv);
 
     //崩溃信号
@@ -172,7 +173,6 @@ int main(int argc, char *argv[])
     app.setApplicationDisplayName("DDE Dock");
     app.setApplicationVersion("2.0");
     app.loadTranslator();
-    app.setAttribute(Qt::AA_EnableHighDpiScaling, true);
     app.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
 
     // 自动化标记由此开始


### PR DESCRIPTION
According to [Qt's documentation](https://doc.qt.io/qt-5/qt.html#ApplicationAttribute-enum)
> Enables high-DPI scaling in Qt on supported platforms (see also [High DPI Displays](https://doc.qt.io/qt-5/highdpi.html)). Supported platforms are X11, Windows and Android. Enabling makes Qt scale the main (device independent) coordinate system according to display scale factors provided by the operating system. This corresponds to setting the QT_AUTO_SCREEN​_SCALE_FACTOR environment variable to 1. This attribute must be set before [QGuiApplication](https://doc.qt.io/qt-5/qguiapplication.html) is constructed. This value was added in Qt 5.6.

AA_EnableHighDpiScaling need to be set before QGuiApplication constructed.

log: