### PR TITLE
chore: use DDE for current desktop name

### DIFF
--- a/frame/main.cpp
+++ b/frame/main.cpp
@@ -152,7 +152,9 @@ bool IsSaveMode()
 
 int main(int argc, char *argv[])
 {
-    if (QString(getenv("XDG_CURRENT_DESKTOP")).compare("deepin", Qt::CaseInsensitive) == 0) {
+    QString currentDesktop = QString(getenv("XDG_CURRENT_DESKTOP"));
+    if (currentDesktop.compare("DDE", Qt::CaseInsensitive) == 0 ||
+        currentDesktop.compare("deepin", Qt::CaseInsensitive) == 0) {
         qDebug() << "Warning: force enable D_DXCB_FORCE_NO_TITLEBAR now!";
         setenv("D_DXCB_FORCE_NO_TITLEBAR", "1", 1);
     }


### PR DESCRIPTION
使用DDE作为当前桌面环境的名称
https://github.com/linuxdeepin/developer-center/issues/3829
log: