### PR TITLE
fix: remove tray item selected status

### DIFF
--- a/frame/window/tray/tray_model.cpp
+++ b/frame/window/tray/tray_model.cpp
@@ -289,7 +289,7 @@ Qt::ItemFlags TrayModel::flags(const QModelIndex &index) const
     const Qt::ItemFlags defaultFlags = QAbstractListModel::flags(index);
     Q_EMIT requestOpenEditor(index);
 
-    return defaultFlags | Qt::ItemIsEditable |  Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled;
+    return (defaultFlags | Qt::ItemIsEditable |  Qt::ItemIsDragEnabled | Qt::ItemIsDropEnabled) & ~Qt::ItemIsSelectable;
 }
 
 int TrayModel::rowCount(const QModelIndex &parent) const


### PR DESCRIPTION
fix https://github.com/linuxdeepin/developer-center/issues/3575
expandIcon can't be draged but can be selected, selected status generated by keep left-clicking undraggable expandIcon.
So by removing selectable attr, selected status will never generated.


log: