### PR TITLE
fix: make keyboard layout plugin size fixed and adjust tray icon size

### DIFF
--- a/frame/window/tray/tray_delegate.cpp
+++ b/frame/window/tray/tray_delegate.cpp
@@ -106,7 +106,7 @@ QWidget *TrayDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem 
     }
 
     if (trayWidget)
-        trayWidget->setFixedSize(16, 16);
+        trayWidget->setFixedSize(ICON_SIZE, ICON_SIZE);
 
     return trayWidget;
 }

--- a/frame/window/tray/tray_delegate.cpp
+++ b/frame/window/tray/tray_delegate.cpp
@@ -86,6 +86,7 @@ QWidget *TrayDelegate::createEditor(QWidget *parent, const QStyleOptionViewItem 
         TrayModel *dataModel = qobject_cast<TrayModel *>(m_listView->model());
         if (IndicatorTrayItem *sourceIndicatorWidget = dataModel->indicatorWidget(key)) {
             connect(indicatorWidget, &IndicatorTrayItem::clicked, sourceIndicatorWidget, &IndicatorTrayItem::clicked);
+            connect(sourceIndicatorWidget, &IndicatorTrayItem::textChanged, indicatorWidget, &IndicatorTrayItem::setText);
             const QByteArray pixmapData = sourceIndicatorWidget->pixmapData();
             if (!pixmapData.isEmpty())
                 indicatorWidget->setPixmapData(pixmapData);

--- a/frame/window/tray/tray_delegate.h
+++ b/frame/window/tray/tray_delegate.h
@@ -11,8 +11,9 @@
 #include <QStyledItemDelegate>
 
 #define ITEM_SIZE 30
-// 托盘图标固定16个像素
-#define ICON_SIZE 16
+// 托盘图标固定20个像素
+// 16 x 16 will make the icon be cut, reserve 2 pixels for each side to prevent being cut
+#define ICON_SIZE 20
 #define ITEM_SPACING 5
 
 class ExpandIconWidget;

--- a/frame/window/tray/widgets/indicatortrayitem.cpp
+++ b/frame/window/tray/widgets/indicatortrayitem.cpp
@@ -21,7 +21,6 @@
 #include <QDBusInterface>
 #include <QDBusReply>
 #include <QApplication>
-#include <qnamespace.h>
 #include <thread>
 #include <DFontSizeManager>
 

--- a/frame/window/tray/widgets/indicatortrayitem.h
+++ b/frame/window/tray/widgets/indicatortrayitem.h
@@ -7,6 +7,7 @@
 
 #include <QScopedPointer>
 #include <QLabel>
+#include <QPaintEvent>
 
 #include "basetraywidget.h"
 
@@ -31,17 +32,21 @@ public:
     const QString text() const;
     bool containsPoint(const QPoint &mouse) override { return false; }
 
+private:
+    void paintEvent(QPaintEvent *) override;
+
 public Q_SLOTS:
     Q_SCRIPTABLE void setPixmapData(const QByteArray &data);
     Q_SCRIPTABLE void setText(const QString &text);
 
 Q_SIGNALS:
     void clicked(uint8_t, int, int);
+    void textChanged(const QString &text);
 
 private:
-    QLabel *m_label;
     QString m_indicatorName;
     bool m_enableClick;              // 置灰时设置为false，不触发click信号
     QByteArray m_pixmapData;
+    QString m_text;
 };
 


### PR DESCRIPTION
1. indicator icon size shou be fixed same as other tray icon, should not change follow system font size.
2. add text change info from sourceIndicatorWidget to display indicatorWidget
3. adjust tray icon to 20 pixel.

Resolve: https://github.com/linuxdeepin/developer-center/issues/3834
Resolve: https://github.com/linuxdeepin/developer-center/issues/4321