### PR TITLE
fix: 最近使用应用栏出现Deepin Lock

### DIFF
--- a/frame/controller/dockitemmanager.cpp
+++ b/frame/controller/dockitemmanager.cpp
@@ -41,7 +41,9 @@ DockItemManager::DockItemManager(QObject *parent)
         connect(it, &AppItem::windowCountChanged, this, &DockItemManager::onAppWindowCountChanged);
         connect(this, &DockItemManager::requestUpdateDockItem, it, &AppItem::requestUpdateEntryGeometries);
 
-        m_itemList.append(it);
+        // 屏蔽Deepin Lock
+        if (it->name() != QStringLiteral("Deepin Lock"))
+            m_itemList.append(it);
         updateMultiItems(it);
     }
 


### PR DESCRIPTION
屏蔽了Deepin Lock的显示
Fix https://github.com/linuxdeepin/developer-center/issues/3788

Log: 最近使用应用栏出现Deepin Lock