### PR TITLE
fix: fix quick control panel display text incorrectly when fontSize set to 20

### DIFF
--- a/plugins/bluetooth/bluetoothmainwidget.cpp
+++ b/plugins/bluetooth/bluetoothmainwidget.cpp
@@ -98,6 +98,9 @@ bool BluetoothMainWidget::eventFilter(QObject *watcher, QEvent *event)
     if (watcher == m_nameLabel && event->type() == QEvent::Resize) {
         m_nameLabel->setText(QFontMetrics(m_nameLabel->font()).elidedText(tr("Bluetooth"), Qt::TextElideMode::ElideRight, m_nameLabel->width()));
     }
+    if (watcher == m_stateLabel && event->type() == QEvent::Resize) {
+        m_stateLabel->setText(QFontMetrics(m_stateLabel->font()).elidedText(m_stateLabel->text(), Qt::TextElideMode::ElideRight, m_stateLabel->width()));
+    }
     return QWidget::eventFilter(watcher, event);
 }
 
@@ -119,6 +122,7 @@ void BluetoothMainWidget::initUi()
 
     m_stateLabel->setParent(textWidget);
     m_stateLabel->setFont(DFontSizeManager::instance()->t10());
+    m_stateLabel->setFixedWidth(76);
     textLayout->addWidget(m_nameLabel);
     textLayout->addWidget(m_stateLabel);
 
@@ -130,7 +134,8 @@ void BluetoothMainWidget::initUi()
     expandLayout->addWidget(m_expandLabel);
 
     // 设置图标和文本
-    m_nameLabel->setText(tr("Bluetooth"));
+    m_nameLabel->setText(QFontMetrics{m_nameLabel->font()}.elidedText(tr("Bluetooth"), Qt::TextElideMode::ElideRight, m_nameLabel->width()));
+    m_stateLabel->setText(QFontMetrics{m_stateLabel->font()}.elidedText(isOpen() ? tr("Turn on") : tr("Turn off"), Qt::TextElideMode::ElideRight,m_stateLabel->width()));
     updateExpandIcon();
 
     // 将所有的窗体都添加到主布局中
@@ -189,6 +194,8 @@ QString BluetoothMainWidget::bluetoothIcon(bool isOpen) const
 void BluetoothMainWidget::onAdapterChanged()
 {
     bool bluetoothIsOpen = isOpen();
-    m_stateLabel->setText(bluetoothIsOpen ? tr("Turn on") : tr("Turn off"));
+    const QString& text = bluetoothIsOpen ? tr("Turn on") : tr("Turn off");
+    QFontMetrics fmt{m_stateLabel->font()};
+    m_stateLabel->setText(fmt.elidedText(text, Qt::TextElideMode::ElideRight,m_stateLabel->width()));
     m_iconWidget->update();
 }

--- a/plugins/pluginmanager/standardquickitem.cpp
+++ b/plugins/pluginmanager/standardquickitem.cpp
@@ -13,9 +13,9 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 
-#define ICONHEIGHT 24
-#define ICONWIDTH 24
-#define TEXTHEIGHT 11
+static constexpr int ICONHEIGHT = 24;
+static constexpr int ICONWIDTH = 24;
+static constexpr int TEXTHEIGHT = 20;
 
 DWIDGET_USE_NAMESPACE
 
@@ -96,6 +96,7 @@ QWidget *StandardQuickItem::iconWidget(QWidget *parent)
         QLabel *labelText = new QLabel(widget);
         labelText->setObjectName("textLabel");
         labelText->setFixedHeight(TEXTHEIGHT);
+        labelText->setFixedWidth(this->width());
         updatePluginName(labelText);
         labelText->setAlignment(Qt::AlignCenter);
         labelText->setFont(DFontSizeManager::instance()->t10());
@@ -152,12 +153,16 @@ void StandardQuickItem::updatePluginName(QLabel *textLabel)
 {
     if (!textLabel)
         return;
-
     QString text = pluginItem()->description();
     if (text.isEmpty())
         text = pluginItem()->pluginDisplayName();
     QFontMetrics ftm(textLabel->font());
-    text = ftm.elidedText(text, Qt::TextElideMode::ElideRight, textLabel->width());
+    if (ftm.boundingRect(text).width() > textLabel->width()) {
+        this->setToolTip(text);
+    } else {
+        this->setToolTip("");
+    }
+    text = ftm.elidedText(text, Qt::TextElideMode::ElideMiddle, textLabel->width());
     textLabel->setText(text);
 }
 

--- a/plugins/power/powerplugin.cpp
+++ b/plugins/power/powerplugin.cpp
@@ -215,8 +215,10 @@ void PowerPlugin::refreshTipsData()
 {
     const BatteryPercentageMap data = m_powerInter->batteryPercentage();
     const uint percentage = qMin(100.0, qMax(0.0, data.value("Display")));
-    const QString value = QString("%1%").arg(std::round(percentage));
+    QString value = QString("%1%").arg(std::round(percentage));
     const int batteryState = m_powerInter->batteryState()["Display"];
+    QFontMetrics ftm(m_labelText->font());
+    value = ftm.elidedText(value, Qt::TextElideMode::ElideMiddle, m_labelText->width());
     m_labelText->setText(value);
     if (m_preChargeTimer->isActive() && m_showTimeToFull) {
         // 插入电源后，20秒内算作预充电时间，此时计算剩余充电时间是不准确的
@@ -291,7 +293,7 @@ void PowerPlugin::initUi()
 
     m_labelText = new QLabel(m_quickPanel);
     m_labelText->setObjectName("textLabel");
-    m_labelText->setFixedHeight(11);
+    m_labelText->setFixedHeight(15);
     m_labelText->setAlignment(Qt::AlignCenter);
     m_labelText->setFont(Dtk::Widget::DFontSizeManager::instance()->t10());
     layout->addWidget(m_imageLabel);


### PR DESCRIPTION
修复dde-dock的逻辑,但自定义插件需要各应用自己修复相关逻辑

resolve: https://github.com/linuxdeepin/developer-center/issues/3574

Log: 修复当字体大小设置为20时控制面板字体显示错误