### PR TITLE
fix: tray always reset while dragging quickItem to trayDock

### DIFF
--- a/frame/window/quickpluginmodel.cpp
+++ b/frame/window/quickpluginmodel.cpp
@@ -155,6 +155,11 @@ void QuickPluginModel::saveConfig()
     std::sort(plugins.begin(), plugins.end(), [ this ](const QString &p1, const QString &p2) {
         return m_dockedPluginIndex.value(p1) < m_dockedPluginIndex.value(p2);
     });
+
+    for (const auto &originalPlugin : SETTINGCONFIG->value(PLUGINNAMEKEY).toStringList()) {
+        if (!plugins.contains(originalPlugin)) plugins.append(originalPlugin);
+    }
+
     SETTINGCONFIG->setValue(PLUGINNAMEKEY, plugins);
 }
 


### PR DESCRIPTION
resolve: https://github.com/linuxdeepin/developer-center/issues/3915

Log: 修复拖动快捷插件到托盘上时托盘总被重置的问题