### PR TITLE
fix dock Fixed_plugin disappear after dragging and setting in control center

### DIFF
--- a/frame/window/mainpanelcontrol.cpp
+++ b/frame/window/mainpanelcontrol.cpp
@@ -813,7 +813,7 @@ void MainPanelControl::startDrag(DockItem *dockItem)
             appItem->setDraging(false);
             appItem->undock();
         }
-    } else if (m_dragIndex == -1) {
+    } else {
         m_appDragWidget = nullptr;
         item->setDraging(false);
         item->update();

--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -72,7 +72,13 @@ void MultitaskingPlugin::init(PluginProxyInterface *proxyInter)
 const QString MultitaskingPlugin::itemCommand(const QString &itemKey)
 {
     if (itemKey == PLUGIN_KEY)
-        return "dbus-send --session --dest=com.deepin.wm --print-reply /com/deepin/wm com.deepin.wm.PerformAction int32:1";
+        DDBusSender()
+            .service("com.deepin.wm")
+            .interface("com.deepin.wm")
+            .path("/com/deepin/wm")
+            .method(QString("PerformAction"))
+            .arg(1)
+            .call();
 
     return "";
 }

--- a/plugins/pluginmanager/dockplugincontroller.cpp
+++ b/plugins/pluginmanager/dockplugincontroller.cpp
@@ -704,8 +704,8 @@ void DockPluginController::onConfigChanged(const QString &key, const QVariant &v
         } else if (canDock && !isPluginLoaded(plugin)) {
             // 如果当前配置中包含当前插件，但是当前插件并未加载，那么就加载该插件
             addPluginItem(plugin, itemKey);
-            // 只有工具插件是通过QWidget的方式进行显示的，因此，这里只处理工具插件
-            if (plugin->flags() & PluginFlag::Type_Tool) {
+            // 工具|固定区域 插件是通过QWidget的方式进行显示的
+            if (plugin->flags() & (PluginFlag::Type_Tool | PluginFlag::Type_Fixed)) {
                 QWidget *itemWidget = plugin->itemWidget(itemKey);
                 if (itemWidget)
                     itemWidget->setVisible(true);


### PR DESCRIPTION
1. after dragging nothing handle non-app item restore, while it has a right index
2. Fixed_Plugin also uses QWidget to show, so it also need to set visible after readded
3. multitasking use dbus call direct instead of calling a QProcess