### PR TITLE
fix: disk popup does not hide

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -155,16 +155,27 @@ void DockPopupWindow::enterEvent(QEvent *e)
 
 bool DockPopupWindow::eventFilter(QObject *o, QEvent *e)
 {
-    if (o != getContent() || e->type() != QEvent::Resize)
+    if (o != getContent())
         return false;
 
-    // FIXME: ensure position move after global mouse release event
-    if (isVisible()) {
-        QTimer::singleShot(10, this, [=] {
-            // NOTE(sbw): double check is necessary, in this time, the popup maybe already hided.
-            if (isVisible())
-                show(m_lastPoint, m_model);
-        });
+    switch(e->type()) {
+    case QEvent::Resize: {
+        // FIXME: ensure position move after global mouse release event
+        if (isVisible()) {
+            QTimer::singleShot(10, this, [=] {
+                // NOTE(sbw): double check is necessary, in this time, the popup maybe already hided.
+                if (isVisible())
+                    show(m_lastPoint, m_model);
+            });
+        }
+        break;
+    }
+    case QEvent::Hide: {
+        this->hide();
+        break;
+    }
+    default:
+        break;
     }
 
     return false;

--- a/plugins/pluginmanager/dockplugincontroller.cpp
+++ b/plugins/pluginmanager/dockplugincontroller.cpp
@@ -260,6 +260,10 @@ void DockPluginController::removePluginItem(PluginsItemInterface * const itemInt
     PluginInfo *pluginInfo = static_cast<PluginInfo *>(interfaceData[PLUGININFO]);
     // 将是否在任务栏显示的标记改为不显示
     pluginInfo->m_visible = false;
+
+    if (QWidget * popup = itemInter->itemPopupApplet(itemKey))
+        popup->hide();
+
     m_proxyInter->itemRemoved(itemInter, itemKey);
 }
 


### PR DESCRIPTION
Disk popup does hide after all disks are ejected. Hide popup of a pluin in itemRemoved, and notify the DockPopupWindow to hide too.

Log: fix disk popup does not hide
Issue: 3813