### PR TITLE
fix: fix xembed tray flew out

### DIFF
--- a/frame/window/tray/widgets/xembedtrayitemwidget.cpp
+++ b/frame/window/tray/widgets/xembedtrayitemwidget.cpp
@@ -251,13 +251,12 @@ void XEmbedTrayItemWidget::wrapWindow()
 
     xcb_flush(c);
 
-    if (isVisible()) {
-        xcb_map_window(c, m_containerWid);
 
-        xcb_reparent_window(c, m_windowId,
-                            m_containerWid,
-                            0, 0);
-    }
+    xcb_map_window(c, m_containerWid);
+
+    xcb_reparent_window(c, m_windowId,
+                        m_containerWid,
+                        0, 0);
 
     /*
      * Render the embedded window offscreen


### PR DESCRIPTION
fix https://github.com/linuxdeepin/developer-center/issues/3635

xcb create window must map to xembedtray widget, otherwise the window will fly out
