### PR TITLE
feat: DockPopupWindow改用DBlurEffectWidget实现

### DIFF
--- a/frame/item/components/appdragwidget.cpp
+++ b/frame/item/components/appdragwidget.cpp
@@ -32,12 +32,6 @@ AppDragWidget::AppDragWidget(QWidget *parent)
     , m_item(nullptr)
     , m_dockScreen(nullptr)
 {
-    m_popupWindow->setShadowBlurRadius(20);
-    m_popupWindow->setRadius(18);
-    m_popupWindow->setShadowYOffset(2);
-    m_popupWindow->setShadowXOffset(0);
-    m_popupWindow->setArrowWidth(18);
-    m_popupWindow->setArrowHeight(10);
     m_popupWindow->setRadius(18);
 
     m_scene->addItem(m_object.get());

--- a/frame/item/dockitem.cpp
+++ b/frame/item/dockitem.cpp
@@ -31,19 +31,14 @@ DockItem::DockItem(QWidget *parent)
     , m_popupAdjustDelayTimer(new QTimer(this))
 {
     if (PopupWindow.isNull()) {
-        DockPopupWindow *arrowRectangle = new DockPopupWindow(nullptr);
-        arrowRectangle->setShadowBlurRadius(20);
-        arrowRectangle->setRadius(18);
-        arrowRectangle->setShadowYOffset(2);
-        arrowRectangle->setShadowXOffset(0);
-        arrowRectangle->setArrowWidth(18);
-        arrowRectangle->setArrowHeight(10);
-        arrowRectangle->setObjectName("apppopup");
+        DockPopupWindow *blurRectangle = new DockPopupWindow(nullptr);
+        blurRectangle->setRadius(18);
+        blurRectangle->setObjectName("apppopup");
         if (Utils::IS_WAYLAND_DISPLAY) {
-            Qt::WindowFlags flags = arrowRectangle->windowFlags() | Qt::FramelessWindowHint;
-            arrowRectangle->setWindowFlags(flags);
+            Qt::WindowFlags flags = blurRectangle->windowFlags() | Qt::FramelessWindowHint;
+            blurRectangle->setWindowFlags(flags);
         }
-        PopupWindow = arrowRectangle;
+        PopupWindow = blurRectangle;
         connect(qApp, &QApplication::aboutToQuit, PopupWindow, &DockPopupWindow::deleteLater);
     }
 
@@ -271,9 +266,9 @@ void DockItem::showHoverTips()
 
 void DockItem::showPopupWindow(QWidget *const content, const bool model)
 {
-    if(itemType() == App){
+    if (itemType() == App) {
         PopupWindow->setRadius(18);
-    }else {
+    } else {
         PopupWindow->setRadius(6);
     }
 
@@ -288,13 +283,8 @@ void DockItem::showPopupWindow(QWidget *const content, const bool model)
     if (lastContent)
         lastContent->setVisible(false);
 
-    switch (DockPosition) {
-    case Top:   popup->setArrowDirection(DockPopupWindow::ArrowTop);     break;
-    case Bottom: popup->setArrowDirection(DockPopupWindow::ArrowBottom);  break;
-    case Left:  popup->setArrowDirection(DockPopupWindow::ArrowLeft);    break;
-    case Right: popup->setArrowDirection(DockPopupWindow::ArrowRight);   break;
-    }
     popup->resize(content->sizeHint());
+    popup->setPosition(DockPosition);
     popup->setContent(content);
 
     const QPoint p = popupMarkPoint();
@@ -359,16 +349,16 @@ const QPoint DockItem::popupMarkPoint()
     const QRect r = rect();
     switch (DockPosition) {
     case Top:
-        p += QPoint(r.width() / 2, r.height());
+        p += QPoint(r.width() / 2, r.height() + POPUP_PADDING);
         break;
     case Bottom:
-        p += QPoint(r.width() / 2, 0);
+        p += QPoint(r.width() / 2, -POPUP_PADDING);
         break;
     case Left:
-        p += QPoint(r.width(), r.height() / 2);
+        p += QPoint(r.width() + POPUP_PADDING, r.height() / 2);
         break;
     case Right:
-        p += QPoint(0, r.height() / 2);
+        p += QPoint(-POPUP_PADDING, r.height() / 2);
         break;
     }
     return p;

--- a/frame/util/dockpopupwindow.h
+++ b/frame/util/dockpopupwindow.h
@@ -7,17 +7,22 @@
 #define DOCKPOPUPWINDOW_H
 
 #include "org_deepin_dde_xeventmonitor1.h"
+#include "constants.h"
 
-#include <darrowrectangle.h>
+#include <DBlurEffectWidget>
 #include <dregionmonitor.h>
 #include <DWindowManagerHelper>
+
+#include <QVBoxLayout>
+#include <QPainter>
+#include <QMouseEvent>
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
 
 using XEventMonitor = org::deepin::dde::XEventMonitor1;
 
-class DockPopupWindow : public Dtk::Widget::DArrowRectangle
+class DockPopupWindow : public Dtk::Widget::DBlurEffectWidget
 {
     Q_OBJECT
 
@@ -27,9 +32,11 @@ public:
 
     bool model() const;
 
+    QWidget *getContent();
     void setContent(QWidget *content);
     void setExtendWidget(QWidget *widget);
-    QWidget *extengWidget() const;
+    void setPosition(Dock::Position position);
+    QWidget *extendWidget() const;
 
 public slots:
     void show(const QPoint &pos, const bool model = false);
@@ -52,19 +59,20 @@ protected:
     void blockButtonRelease();
 
 private slots:
-    void compositeChanged();
     void ensureRaised();
     void onButtonPress(int type, int x, int y, const QString &key);
 
 private:
     bool m_model;
     QPoint m_lastPoint;
+    Dock::Position m_position;
 
     XEventMonitor *m_eventMonitor;
     QString m_eventKey;
     DWindowManagerHelper *m_wmHelper;
     bool m_enableMouseRelease;
     QWidget *m_extendWidget;
+    QPointer<QWidget> m_lastWidget;
 };
 
 class PopupSwitchWidget : public QWidget

--- a/frame/window/components/datetimedisplayer.cpp
+++ b/frame/window/components/datetimedisplayer.cpp
@@ -18,6 +18,7 @@
 #include <QFont>
 #include <QMenu>
 #include <QPainterPath>
+#include <QMouseEvent>
 
 DWIDGET_USE_NAMESPACE
 DGUI_USE_NAMESPACE
@@ -84,32 +85,19 @@ void DateTimeDisplayer::setOneRow(bool oneRow)
 
 void DateTimeDisplayer::updatePolicy()
 {
-    switch (m_position) {
-    case Dock::Position::Top: {
+    switch(m_position) {
+    case Dock::Position::Top:
+    case Dock::Position::Bottom:
         setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-        m_tipPopupWindow->setArrowDirection(DArrowRectangle::ArrowDirection::ArrowTop);
-        m_tipPopupWindow->setContent(m_tipsWidget);
         break;
-    }
-    case Dock::Position::Bottom: {
-        setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
-        m_tipPopupWindow->setArrowDirection(DArrowRectangle::ArrowDirection::ArrowBottom);
-        m_tipPopupWindow->setContent(m_tipsWidget);
-        break;
-    }
-    case Dock::Position::Left: {
+    case Dock::Position::Left:
+    case Dock::Position::Right:
         setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-        m_tipPopupWindow->setArrowDirection(DArrowRectangle::ArrowDirection::ArrowLeft);
-        m_tipPopupWindow->setContent(m_tipsWidget);
         break;
     }
-    case Dock::Position::Right: {
-        setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
-        m_tipPopupWindow->setArrowDirection(DArrowRectangle::ArrowDirection::ArrowRight);
-        m_tipPopupWindow->setContent(m_tipsWidget);
-        break;
-    }
-    }
+
+    m_tipPopupWindow->setPosition(m_position);
+    m_tipPopupWindow->setContent(m_tipsWidget);
 }
 
 QSize DateTimeDisplayer::suitableSize() const
@@ -296,15 +284,15 @@ void DateTimeDisplayer::paintEvent(QPaintEvent *e)
 
 QPoint DateTimeDisplayer::tipsPoint() const
 {
-    QPoint pointInTopWidget = parentWidget()->mapTo(topLevelWidget(), pos());
+    QPoint pointInTopWidget = parentWidget()->mapTo(window(), pos());
     switch (m_position) {
     case Dock::Position::Left: {
-        pointInTopWidget.setX(topLevelWidget()->x() + topLevelWidget()->width());
+        pointInTopWidget.setX(window()->x() + window()->width());
         pointInTopWidget.setY(pointInTopWidget.y() + height() / 2);
         break;
     }
     case Dock::Position::Top: {
-        pointInTopWidget.setY(y() + topLevelWidget()->y() + topLevelWidget()->height());
+        pointInTopWidget.setY(y() + window()->y() + window()->height());
         pointInTopWidget.setX(pointInTopWidget.x() + width() / 2);
         break;
     }
@@ -314,12 +302,12 @@ QPoint DateTimeDisplayer::tipsPoint() const
         break;
     }
     case Dock::Position::Bottom: {
-        pointInTopWidget.setY(0);
+        pointInTopWidget.setY(-POPUP_PADDING);
         pointInTopWidget.setX(pointInTopWidget.x() + width() / 2);
         break;
     }
     }
-    return topLevelWidget()->mapToGlobal(pointInTopWidget);
+    return window()->mapToGlobal(pointInTopWidget);
 }
 
 QFont DateTimeDisplayer::timeFont() const

--- a/frame/window/docktraywindow.cpp
+++ b/frame/window/docktraywindow.cpp
@@ -20,6 +20,7 @@
 
 #include <QBoxLayout>
 #include <QLabel>
+#include <QPainter>
 
 #define FRONTSPACING 18
 #define SPLITERSIZE 2

--- a/frame/window/systempluginwindow.cpp
+++ b/frame/window/systempluginwindow.cpp
@@ -15,6 +15,7 @@
 #include <QDir>
 #include <QMetaObject>
 #include <QGuiApplication>
+#include <QPainter>
 
 #define MAXICONSIZE 48
 #define MINICONSIZE 24

--- a/frame/window/tray/tray_delegate.cpp
+++ b/frame/window/tray/tray_delegate.cpp
@@ -25,6 +25,7 @@
 #include <QKeyEvent>
 #include <QApplication>
 #include <QPainterPath>
+#include <QPainter>
 
 #include <xcb/xcb_icccm.h>
 #include <X11/Xlib.h>

--- a/frame/window/tray/widgets/snitrayitemwidget.cpp
+++ b/frame/window/tray/widgets/snitrayitemwidget.cpp
@@ -17,6 +17,7 @@
 #include <QDBusPendingCall>
 #include <QtConcurrent>
 #include <QFuture>
+#include <QMouseEvent>
 
 #include <xcb/xproto.h>
 
@@ -54,12 +55,7 @@ SNITrayItemWidget::SNITrayItemWidget(const QString &sniServicePath, QWidget *par
 
     if (PopupWindow.isNull()) {
         DockPopupWindow *arrowRectangle = new DockPopupWindow(nullptr);
-        arrowRectangle->setShadowBlurRadius(20);
         arrowRectangle->setRadius(6);
-        arrowRectangle->setShadowYOffset(2);
-        arrowRectangle->setShadowXOffset(0);
-        arrowRectangle->setArrowWidth(18);
-        arrowRectangle->setArrowHeight(10);
         arrowRectangle->setObjectName("snitraypopup");
         PopupWindow = arrowRectangle;
         if (Utils::IS_WAYLAND_DISPLAY)
@@ -757,12 +753,7 @@ void SNITrayItemWidget::showPopupWindow(QWidget *const content, const bool model
     if (lastContent)
         lastContent->setVisible(false);
 
-    switch (DockPosition) {
-    case Dock::Position::Top:   popup->setArrowDirection(DockPopupWindow::ArrowTop);     break;
-    case Dock::Position::Bottom: popup->setArrowDirection(DockPopupWindow::ArrowBottom);  break;
-    case Dock::Position::Left:  popup->setArrowDirection(DockPopupWindow::ArrowLeft);    break;
-    case Dock::Position::Right: popup->setArrowDirection(DockPopupWindow::ArrowRight);   break;
-    }
+    popup->setPosition(DockPosition);
     popup->resize(content->sizeHint());
     popup->setContent(content);
 

--- a/frame/window/tray/widgets/systempluginitem.cpp
+++ b/frame/window/tray/widgets/systempluginitem.cpp
@@ -50,12 +50,7 @@ SystemPluginItem::SystemPluginItem(PluginsItemInterface *const pluginInter, cons
 
     if (PopupWindow.isNull()) {
         DockPopupWindow *arrowRectangle = new DockPopupWindow(nullptr);
-        arrowRectangle->setShadowBlurRadius(20);
         arrowRectangle->setRadius(6);
-        arrowRectangle->setShadowYOffset(2);
-        arrowRectangle->setShadowXOffset(0);
-        arrowRectangle->setArrowWidth(18);
-        arrowRectangle->setArrowHeight(10);
         arrowRectangle->setObjectName("systemtraypopup");
         if (Utils::IS_WAYLAND_DISPLAY) {
             Qt::WindowFlags flags = arrowRectangle->windowFlags() | Qt::FramelessWindowHint;
@@ -428,12 +423,7 @@ void SystemPluginItem::showPopupWindow(QWidget *const content, const bool model)
     if (lastContent)
         lastContent->setVisible(false);
 
-    switch (DockPosition) {
-    case Dock::Position::Top:   popup->setArrowDirection(DockPopupWindow::ArrowTop);     break;
-    case Dock::Position::Bottom: popup->setArrowDirection(DockPopupWindow::ArrowBottom);  break;
-    case Dock::Position::Left:  popup->setArrowDirection(DockPopupWindow::ArrowLeft);    break;
-    case Dock::Position::Right: popup->setArrowDirection(DockPopupWindow::ArrowRight);   break;
-    }
+    popup->setPosition(DockPosition);
     popup->resize(content->sizeHint());
     popup->setContent(content);
 

--- a/interfaces/constants.h
+++ b/interfaces/constants.h
@@ -89,6 +89,7 @@ enum class AniAction {
 };
 
 #define IS_TOUCH_STATE "isTouchState"
+#define POPUP_PADDING 10
 
 }
 

--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -82,7 +82,7 @@ bool SoundDevicesWidget::eventFilter(QObject *watcher, QEvent *event)
 void SoundDevicesWidget::initUi()
 {
     QVBoxLayout *layout = new QVBoxLayout(this);
-    layout->setContentsMargins(0, 0, 0, 0);
+    layout->setContentsMargins(10, 0, 10, 0);
     layout->setSpacing(6);
 
     m_sliderParent->setFixedHeight(SLIDERHEIGHT);
@@ -103,7 +103,7 @@ void SoundDevicesWidget::initUi()
     sliderLayout->addWidget(m_sliderContainer);
 
     QHBoxLayout *topLayout = new QHBoxLayout(this);
-    topLayout->setContentsMargins(10, 0, 10, 0);
+    topLayout->setContentsMargins(0, 0, 0, 0);
     topLayout->setSpacing(0);
     topLayout->addWidget(m_sliderParent);
 
@@ -238,20 +238,19 @@ void SoundDevicesWidget::startRemovePort(const QString &portId, const uint &card
 void SoundDevicesWidget::addPort(const SoundDevicePort *port)
 {
     DStandardItem *portItem = new DStandardItem;
-    QString deviceName = port->name() + "(" + port->cardName() + ")";
+    QString deviceName = port->name();
     portItem->setIcon(QIcon(soundIconFile()));
     portItem->setText(deviceName);
     portItem->setTextColorRole(QPalette::BrightText);
     portItem->setData(QVariant::fromValue<const SoundDevicePort *>(port), DeviceObjRole);
     portItem->setData(AUDIOPORT, ItemTypeRole);
+    portItem->setToolTip(port->cardName());
 
     connect(port, &SoundDevicePort::nameChanged, this, [ = ](const QString &str) {
-        QString devName = str + "(" + port->cardName() + ")";
-        portItem->setText(devName);
+        portItem->setText(str);
     });
     connect(port, &SoundDevicePort::cardNameChanged, this, [ = ](const QString &str) {
-        QString devName = port->name() + "(" + str + ")";
-        portItem->setText(devName);
+        portItem->setToolTip(str);
     });
     connect(port, &SoundDevicePort::isActiveChanged, this, [ = ](bool isActive) {
         portItem->setCheckState(isActive ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);


### PR DESCRIPTION
DockPopupWindow改为使用DBlurEffectWidget来实现新的设计，以及摆脱原来DArrowRectangle出现的侧边任务栏PopupWindow圆角显示不对称的问题．同时，当前遗留有QuickPlugin与DateTimePlayer的HoverTip Padding和其他不太一致的问题．

Log: DockPopupWindow改用DBlurEffectWidget实现