### PR TITLE
fix: when multiscreen connected non-primary display unable to click p…

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -199,15 +199,15 @@ void DockPopupWindow::onButtonPress(int type, int x, int y, const QString &key)
 {
     if (!m_enableMouseRelease)
         return;
-
-    QRect popupRect(pos() * qApp->devicePixelRatio(), size() * qApp->devicePixelRatio()) ;
-    if (popupRect.contains(x, y))
+    QRect screenRect = this->screen()->geometry();
+    QRect popupRect(((pos() - screenRect.topLeft()) * qApp->devicePixelRatio() + screenRect.topLeft()), size() * qApp->devicePixelRatio());
+    if (popupRect.contains(QPoint(x, y)))
         return;
 
     if (m_extendWidget) {
         // 计算额外添加的区域，如果鼠标的点击点在额外的区域内，也无需隐藏
         QPoint extendPoint = m_extendWidget->mapToGlobal(QPoint(0, 0));
-        QRect extendRect(extendPoint * qApp->devicePixelRatio(), m_extendWidget->size() * qApp->devicePixelRatio());
+        QRect extendRect(((extendPoint - screenRect.topLeft()) * qApp->devicePixelRatio() + screenRect.topLeft()), m_extendWidget->size() * qApp->devicePixelRatio());
         if (extendRect.contains(QPoint(x, y)))
             return;
     }


### PR DESCRIPTION
when devicePixelRatio > 1, there is a gap between multiple screens,
before currentPos multiplying by the devicePixelAatio need to subtract the topleft of the current screen and then replus the current screen topleft.

log: fix wrong multiScreen click pos