### PR TITLE
fix: 任务栏快捷面板的电池插件图标显示异常

### DIFF
--- a/plugins/bluetooth/bluetoothplugin.cpp
+++ b/plugins/bluetooth/bluetoothplugin.cpp
@@ -126,9 +126,6 @@ void BluetoothPlugin::refreshIcon(const QString &itemKey)
 
 QIcon BluetoothPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-    if (dockPart == DockPart::QuickPanel)
-        return QIcon();
-
     QString iconFile;
     if (themeType == DGuiApplicationHelper::ColorType::DarkType)
         iconFile = ":/bluetooth-active-symbolic.svg";

--- a/plugins/power/powerplugin.cpp
+++ b/plugins/power/powerplugin.cpp
@@ -129,11 +129,6 @@ void PowerPlugin::setSortKey(const QString &itemKey, const int order)
 
 QIcon PowerPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-    // 快捷面板使用m_quickPanel
-    if (dockPart == DockPart::QuickPanel) {
-        return QIcon();
-    }
-
     const QPixmap pixmap = m_powerStatusWidget->getBatteryIcon(themeType);
     static QIcon batteryIcon;
     batteryIcon.detach();


### PR DESCRIPTION
蓝牙插件和电源插件属于快捷面板区域插件, 不应该返回空的图标

Log: 修复任务栏快捷面板的电池插件图标显示异常的问题
Resolve: https://github.com/linuxdeepin/developer-center/issues/4004
Influence: 任务栏快捷面板显示