### PR TITLE
fix: when there is focus on dockpopupwindow, it hide

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -213,6 +213,11 @@ void DockPopupWindow::ensureRaised()
 
 void DockPopupWindow::onButtonPress(int type, int x, int y, const QString &key)
 {
+    // if there is something focus on widget, return
+    if (auto focus = qApp->focusWidget()) {
+        qDebug() << "PopupWindow not hide, focus className is" << focus->metaObject()->className();
+        return;
+    }
     if (!m_enableMouseRelease)
         return;
     QRect screenRect = this->screen()->geometry();

--- a/frame/util/dockpopupwindow.h
+++ b/frame/util/dockpopupwindow.h
@@ -52,10 +52,10 @@ signals:
     void unusedSignal();
 
 protected:
-    void showEvent(QShowEvent *e);
-    void hideEvent(QHideEvent *event);
-    void enterEvent(QEvent *e);
-    bool eventFilter(QObject *o, QEvent *e);
+    void showEvent(QShowEvent *e) override;
+    void hideEvent(QHideEvent *event) override;
+    void enterEvent(QEvent *e) override;
+    bool eventFilter(QObject *o, QEvent *e) override;
     void blockButtonRelease();
 
 private slots:


### PR DESCRIPTION
Log: fix when there is focus and dockpopupwindow hide
Resolve: https://github.com/linuxdeepin/developer-center/issues/3830