### PR TITLE
fix: fix timedate display widget size error

### DIFF
--- a/frame/window/components/datetimedisplayer.h
+++ b/frame/window/components/datetimedisplayer.h
@@ -50,6 +50,7 @@ protected:
     void paintEvent(QPaintEvent *e) override;
     void enterEvent(QEvent *event) override;
     void leaveEvent(QEvent *event) override;
+    bool event(QEvent *event) override;
 
 private:
     void updatePolicy();
@@ -75,6 +76,7 @@ private:
     Timedate *m_timedateInter;
     Dock::Position m_position;
     QFont m_dateFont;
+    QFont m_timeFont;
     Dock::TipsWidget *m_tipsWidget;
     QMenu *m_menu;
     QSharedPointer<DockPopupWindow> m_tipPopupWindow;

--- a/frame/window/docktraywindow.cpp
+++ b/frame/window/docktraywindow.cpp
@@ -373,7 +373,8 @@ void DockTrayWindow::onUpdateComponentSize()
     case Dock::Position::Bottom:
         m_toolLineLabel->setFixedSize(SPLITERSIZE, height() * 0.6);
         m_showDesktopWidget->setFixedSize(FRONTSPACING, QWIDGETSIZE_MAX);
-        m_dateTimeWidget->setFixedSize(m_dateTimeWidget->suitableSize().width(), QWIDGETSIZE_MAX);
+        // FIXME: in some cases, m_dateTimeWidget QWIDGETSIZE_MAX get a huge height.
+        m_dateTimeWidget->setFixedSize(m_dateTimeWidget->suitableSize().width(), qMin(QWIDGETSIZE_MAX, this->height()));
         m_systemPuginWidget->setFixedSize(m_systemPuginWidget->suitableSize().width(), QWIDGETSIZE_MAX);
         m_quickIconWidget->setFixedSize(m_quickIconWidget->suitableSize().width(), QWIDGETSIZE_MAX);
         m_trayView->setFixedSize(m_trayView->suitableSize().width(), QWIDGETSIZE_MAX);


### PR DESCRIPTION
when font size changed, timedate widget need to update width and height, and call DFontSizeManager only when font changed.
in some case dateTimeWidget QWIDGETSIZE_MAX will get a huge size, so use `min(QWIDGETSIZE_MAX, parent->height());` limit max height.

log: fix timedate widget size erorr