### PR TITLE
fix: SNI tray menu unable to click

### DIFF
--- a/frame/window/tray/widgets/snitrayitemwidget.cpp
+++ b/frame/window/tray/widgets/snitrayitemwidget.cpp
@@ -168,7 +168,7 @@ void SNITrayItemWidget::sendClick(uint8_t mouseButton, int x, int y)
             // primarily work for apps using libappindicator.
             reply.waitForFinished();
             if (reply.isError()) {
-                showContextMenu(x,y);
+                QMetaObject::invokeMethod(this, "showContextMenu", Q_ARG(int,x), Q_ARG(int, y));
             }
         });
     }


### PR DESCRIPTION
when first left click SNI tray menu and app without activate to show, will get a dbus error and recall right menu
this will case menu unable to click, move recall to another thread

log: fix SNI tray menu unable to click