### PR TITLE
fix: dci icon size incorrect

### DIFF
--- a/plugins/pluginmanager/iconmanager.cpp
+++ b/plugins/pluginmanager/iconmanager.cpp
@@ -50,7 +50,7 @@ QPixmap IconManager::pixmap(DGuiApplicationHelper::ColorType colorType) const
     QPainter pa(&pixmap);
     pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
     pa.fillRect(pixmap.rect(), foreColor);
-    return pixmap.scaled(pixmap.size() / qApp->devicePixelRatio());
+    return pixmap;
 }
 
 PluginsItemInterface *IconManager::findPlugin(const QString &pluginName) const


### PR DESCRIPTION
由于 dci 图标殷勤不再乘以缩放，这里不需要再次处理了
见： https://github.com/linuxdeepin/qt5integration/pull/149

Change-Id: I88b9959be0ec88fb3e420b60d7badc5aef772f1d