### PR TITLE
fix: optimize QFile operation

### DIFF
--- a/plugins/overlay-warning/overlay-warning-plugin.cpp
+++ b/plugins/overlay-warning/overlay-warning-plugin.cpp
@@ -145,11 +145,14 @@ bool OverlayWarningPlugin::isOverlayRoot()
 {
     // ignore live/recovery mode
     QFile cmdline("/proc/cmdline");
-    cmdline.open(QFile::ReadOnly);
+    if (cmdline.open(QIODevice::ReadOnly)) {
     QString content(cmdline.readAll());
     cmdline.close();
     if (content.contains("boot=live")) {
         return false;
+    }
+    } else {
+        qDebug() << "open /proc/cmdline failed! please check permission!!!";
     }
 
     return QString(QStorageInfo::root().fileSystemType()) == OverlayFileSystemType;

--- a/plugins/shutdown/shutdownplugin.cpp
+++ b/plugins/shutdown/shutdownplugin.cpp
@@ -343,6 +343,8 @@ qint64 ShutdownPlugin::get_power_image_size()
     if (file.open(QIODevice::Text | QIODevice::ReadOnly)) {
         size = file.readAll().trimmed().toLongLong();
         file.close();
+    } else {
+        qDebug() << "open /sys/power/image_size failed! please check permission!!!";
     }
 
     return size;


### PR DESCRIPTION
fix:catch QFile open exception
plugins/overlay-warning/overlay-warning-plugin.cpp中isOverlayRoot函数打开/proc/cmdline文件的操作可能会失败需要添加判断语句优化，这里参考的是plugins/shutdown/shutdownplugin.cpp中checkSwap函数打开/proc/swaps文件操作添加了判断语句，可能因为权限不足而无法打开
log: Sat, 15 Apr 2023