### PR TITLE
Fix: optimize QFile operation

### DIFF
--- a/plugins/overlay-warning/overlay-warning-plugin.cpp
+++ b/plugins/overlay-warning/overlay-warning-plugin.cpp
@@ -145,11 +145,14 @@ bool OverlayWarningPlugin::isOverlayRoot()
 {
     // ignore live/recovery mode
     QFile cmdline("/proc/cmdline");
-    cmdline.open(QFile::ReadOnly);
-    QString content(cmdline.readAll());
-    cmdline.close();
-    if (content.contains("boot=live")) {
-        return false;
+    if (cmdline.open(QIODevice::ReadOnly)) {
+        QString content(cmdline.readAll());
+        cmdline.close();
+        if (content.contains("boot=live")) {
+            return false;
+        }
+    } else {
+        qWarning() << "open /proc/cmdline failed! please check permission!!!";
     }
 
     return QString(QStorageInfo::root().fileSystemType()) == OverlayFileSystemType;

--- a/plugins/shutdown/shutdownplugin.cpp
+++ b/plugins/shutdown/shutdownplugin.cpp
@@ -343,6 +343,8 @@ qint64 ShutdownPlugin::get_power_image_size()
     if (file.open(QIODevice::Text | QIODevice::ReadOnly)) {
         size = file.readAll().trimmed().toLongLong();
         file.close();
+    } else {
+        qWarning() << "open /sys/power/image_size failed! please check permission!!!";
     }
 
     return size;
@@ -374,7 +376,7 @@ bool ShutdownPlugin::checkSwap()
 
         file.close();
     } else {
-        qDebug() << "open /proc/swaps failed! please check permission!!!";
+        qWarning() << "open /proc/swaps failed! please check permission!!!";
     }
 
     return hasSwap;


### PR DESCRIPTION
详细描述: plugins/overlay-warning/overlay-warning-plugin.cpp中isOverlayRoot函数打开/proc/cmdline文件的操作可能会失败需要添加判断语句优化，同时为其他打开文件失败处理添加了qWarning报警。
