### PR TITLE
fix: click undock menu which make fixed_plugin hide always

### DIFF
--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -119,14 +119,23 @@ void MultitaskingPlugin::invokedMenuItem(const QString &itemKey, const QString &
 
     if (menuId == "multitasking") {
         DDBusSender()
-        .service("com.deepin.wm")
-        .interface("com.deepin.wm")
-        .path("/com/deepin/wm")
-        .method(QString("PerformAction"))
-        .arg(1)
-        .call();
+            .service("com.deepin.wm")
+            .interface("com.deepin.wm")
+            .path("/com/deepin/wm")
+            .method(QString("PerformAction"))
+            .arg(1)
+            .call();
     } else if (menuId == "remove") {
-        m_proxyInter->itemRemoved(this, PLUGIN_KEY);
+        // m_proxyInter->itemRemoved(this, PLUGIN_KEY);
+        DDBusSender()
+            .service("org.deepin.dde.Dock1")
+            .interface("org.deepin.dde.Dock1")
+            .path("/org/deepin/dde/Dock1")
+            .method(QString("setItemOnDock"))
+            .arg(QString("Dock_Quick_Plugins"))
+            .arg(QString("multitasking"))
+            .arg(false)
+            .call();
     }
 }
 

--- a/plugins/show-desktop/showdesktopplugin.cpp
+++ b/plugins/show-desktop/showdesktopplugin.cpp
@@ -8,6 +8,7 @@
 
 #include <QIcon>
 #include <QDebug>
+#include <DDBusSender>
 
 using namespace Dock;
 ShowDesktopPlugin::ShowDesktopPlugin(QObject *parent)
@@ -98,7 +99,16 @@ void ShowDesktopPlugin::invokedMenuItem(const QString &itemKey, const QString &m
     if (menuId == "show-desktop") {
         QProcess::startDetached("/usr/lib/deepin-daemon/desktop-toggle", QStringList());
     } else if (menuId == "remove") {
-        m_proxyInter->itemRemoved(this, pluginName());
+        // m_proxyInter->itemRemoved(this, pluginName());
+        DDBusSender()
+            .service("org.deepin.dde.Dock1")
+            .interface("org.deepin.dde.Dock1")
+            .path("/org/deepin/dde/Dock1")
+            .method(QString("setItemOnDock"))
+            .arg(QString("Dock_Quick_Plugins"))
+            .arg(QString("show-desktop"))
+            .arg(false)
+            .call();
     }
 }
 


### PR DESCRIPTION
The removal will actually remove the plugin, which will make the removed plugin inaccessible, making it impossible to set the plug-in to the dock in the dde-control-center.

Therefore, instead of calling the remove method, set the plugin to hide from the dock.

log: make fixed_plugin hide instead of removal when click ondock