### PR TITLE
fix: wrong use of dci icon

### DIFF
--- a/plugins/pluginmanager/iconmanager.cpp
+++ b/plugins/pluginmanager/iconmanager.cpp
@@ -44,13 +44,7 @@ void IconManager::setDisplayMode(Dock::DisplayMode displayMode)
 QPixmap IconManager::pixmap(DGuiApplicationHelper::ColorType colorType) const
 {
     // 缺省图标
-    QPixmap pixmap = QIcon::fromTheme("dock-control-panel").pixmap(ITEMSIZE, ITEMSIZE);
-    QColor foreColor = (colorType == DGuiApplicationHelper::ColorType::DarkType ? Qt::white : Qt::black);
-    foreColor.setAlphaF(0.8);
-    QPainter pa(&pixmap);
-    pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-    pa.fillRect(pixmap.rect(), foreColor);
-    return pixmap;
+    return QIcon::fromTheme("dock-control-panel").pixmap(ITEMSIZE, ITEMSIZE);
 }
 
 PluginsItemInterface *IconManager::findPlugin(const QString &pluginName) const


### PR DESCRIPTION
DCI iconengine will automatically switch to correct icon when theme type changes. Application should not do anything after getting the pixmap.

Log: fix wrong use of dci icon