### PR TITLE
fix: after screen-recorder finished, dock will coredump

### DIFF
--- a/frame/window/quickpluginwindow.cpp
+++ b/frame/window/quickpluginwindow.cpp
@@ -382,8 +382,10 @@ void QuickPluginWindow::onRequestUpdate()
         m_mainLayout->addWidget(itemWidget);
     }
 
-    if (countChanged)
+    if (countChanged) {
+        m_dragInfo->dockItem = nullptr;
         Q_EMIT itemCountChanged();
+    }
 }
 
 QPoint QuickPluginWindow::popupPoint(QWidget *widget) const


### PR DESCRIPTION
When screen-recorder finish recording, will notify dock update item, and dock will clean all item and readded back. But m_dragInfo->dockItem still point to old item which has been cleaned.
So dock will coredump, while using this pointer to judge item can drag or not.

Resolve: https://github.com/linuxdeepin/developer-center/issues/4245