### PR TITLE
fix: must set CMAKE_INSTALL_PREFIX before GNUInstallDirs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ endif()
 # generate a compile commands file as complete database for vim-YouCompleteMe or some other similar tools
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# Install settings
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+    set(CMAKE_INSTALL_PREFIX /usr)
+endif ()
 include(GNUInstallDirs)
 
 if (NOT (${CMAKE_BUILD_TYPE} MATCHES "Debug"))
@@ -129,11 +133,6 @@ file(GLOB SRC_PATH
 add_subdirectory("frame")
 add_subdirectory("plugins")
 #add_subdirectory("tests")
-
-# Install settings
-if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX /usr)
-endif ()
 
 ## qm files
 file(GLOB QM_FILES "translations/*.qm")

--- a/plugins/plugin-guide/home_monitor/CMakeLists.txt
+++ b/plugins/plugin-guide/home_monitor/CMakeLists.txt
@@ -94,8 +94,5 @@ target_link_libraries(${PLUGIN_NAME} PRIVATE
     ${DdeDockInterface_LIBRARIES}
 )
 
-# 设置安装路径的前缀(默认为"/usr/local")
-set(CMAKE_INSTALL_PREFIX "/usr")
-
 # 设置执行 make install 时哪个目标应该被 install 到哪个位置
 install(TARGETS ${PLUGIN_NAME} LIBRARY DESTINATION lib/dde-dock/plugins)


### PR DESCRIPTION
Log:
Never modify the value of CMAKE_INSTALL_PREFIX after including GNUInstallDirs ，Otherwise incorrect CMAKE_INSTALL_FULL_XXXX values will be computed