### PR TITLE
fix: set radius for tray inner window

### DIFF
--- a/frame/window/mainwindowbase.cpp
+++ b/frame/window/mainwindowbase.cpp
@@ -37,12 +37,12 @@ DGUI_USE_NAMESPACE
 
 MainWindowBase::MainWindowBase(MultiScreenWorker *multiScreenWorker, QWidget *parent)
     : DBlurEffectWidget(parent)
+    , m_platformWindowHandle(this)
     , m_displayMode(Dock::DisplayMode::Efficient)
     , m_position(Dock::Position::Bottom)
     , m_dragWidget(new DragWidget(this))
     , m_multiScreenWorker(multiScreenWorker)
     , m_updateDragAreaTimer(new QTimer(this))
-    , m_platformWindowHandle(this)
     , m_shadowMaskOptimizeTimer(new QTimer(this))
     , m_isShow(false)
     , m_order(0)

--- a/frame/window/mainwindowbase.h
+++ b/frame/window/mainwindowbase.h
@@ -89,13 +89,15 @@ private Q_SLOTS:
     void onCompositeChanged();
     void onThemeTypeChanged(DGuiApplicationHelper::ColorType themeType);
 
+protected:
+    DPlatformWindowHandle m_platformWindowHandle;
+
 private:
     Dock::DisplayMode m_displayMode;
     Dock::Position m_position;
     DragWidget *m_dragWidget;
     MultiScreenWorker *m_multiScreenWorker;
     QTimer *m_updateDragAreaTimer;
-    DPlatformWindowHandle m_platformWindowHandle;
     QTimer *m_shadowMaskOptimizeTimer;
     bool m_isShow;
     int m_order;

--- a/frame/window/traymainwindow.cpp
+++ b/frame/window/traymainwindow.cpp
@@ -121,11 +121,6 @@ int TrayMainWindow::dockSpace() const
     return 0;
 }
 
-void TrayMainWindow::updateRadius(int borderRadius)
-{
-    m_trayManager->updateBorderRadius(borderRadius);
-}
-
 QSize TrayMainWindow::suitableSize(const Dock::Position &pos, const int &, const double &) const
 {
     return m_trayManager->suitableSize(pos);
@@ -134,11 +129,15 @@ QSize TrayMainWindow::suitableSize(const Dock::Position &pos, const int &, const
 void TrayMainWindow::initUI()
 {
     m_trayManager->move(0, 0);
+    m_trayManager->updateBorderRadius(MainWindowBase::m_platformWindowHandle.windowRadius());
 }
 
 void TrayMainWindow::initConnection()
 {
     connect(m_trayManager, &TrayManagerWindow::requestUpdate, this, &TrayMainWindow::onRequestUpdate);
+    connect(&(MainWindowBase::m_platformWindowHandle), &DTK_NAMESPACE::Widget::DPlatformWindowHandle::windowRadiusChanged, m_trayManager, [=]{
+        m_trayManager->updateBorderRadius(MainWindowBase::m_platformWindowHandle.windowRadius());
+    });
 }
 
 void TrayMainWindow::onRequestUpdate()

--- a/frame/window/traymainwindow.h
+++ b/frame/window/traymainwindow.h
@@ -34,7 +34,6 @@ public:
 
 protected:
     int dockSpace() const override;
-    void updateRadius(int borderRadius) override;
 
 private:
     void initUI();


### PR DESCRIPTION
make m_platformWindowHandle protected so subclass can connect to windowRadiusChanged signal, which make traymainwindow radius change follow mainwindow

log: make trymainwindows radius changed follow mainwindow