### PR TITLE
fix: trash do not display when dock hide and trash readded into dock

### DIFF
--- a/frame/controller/toolapphelper.cpp
+++ b/frame/controller/toolapphelper.cpp
@@ -60,8 +60,6 @@ void ToolAppHelper::appendToToolArea(int index, DockItem *dockItem)
         boxLayout->insertWidget(index, dockItem);
     else
         boxLayout->addWidget(dockItem);
-
-    Q_EMIT requestUpdate();
 }
 
 bool ToolAppHelper::removeToolArea(PluginsItemInterface *itemInter)


### PR DESCRIPTION
relayout after updateToolArea otherwise plugin item size will set to 0

log:  only relayout after update visiable