### PR TITLE
fix: dock position changed from left to bottom no date display

### DIFF
--- a/frame/window/components/datetimedisplayer.cpp
+++ b/frame/window/components/datetimedisplayer.cpp
@@ -419,6 +419,7 @@ bool DateTimeDisplayer::event(QEvent *event)
         m_timeFont = timeFont();
         Q_EMIT requestUpdate();
     } else if (event->type() == QEvent::Resize) {
+        m_dateFont = DFontSizeManager::instance()->t10();
         m_timeFont = timeFont();
     }
     return QWidget::event(event);


### PR DESCRIPTION
update dateFont size when DateTimeDisplayer size changed.