### PR TITLE
fix: DockPopupWindow losing active status

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -143,6 +143,7 @@ void DockPopupWindow::show(const int x, const int y)
     move(displayPoint);
     resize(m_lastWidget->size());
     DBlurEffectWidget::show();
+    activateWindow();
 }
 
 void DockPopupWindow::blockButtonRelease()


### PR DESCRIPTION
  It causes that child widgets doesn't have focus even though
calling setFocus.
  It was introduced by ec5c447264087420d8ec80a18e7f2bcc4f683a74.
because that DArrowRectangle has activateWindow when show.

Issue: https://pms.uniontech.com/bug-view-172773.html