### PR TITLE
fix: 任务栏声音面板中出现异常的悬浮提示

### DIFF
--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -272,14 +272,10 @@ void SoundDevicesWidget::addPort(const SoundDevicePort *port)
     portItem->setTextColorRole(QPalette::BrightText);
     portItem->setData(QVariant::fromValue<const SoundDevicePort *>(port), DeviceObjRole);
     portItem->setData(AUDIOPORT, ItemTypeRole);
-    portItem->setToolTip(port->cardName());
     static QBrush oldBackGroundStyle = portItem->background();
 
     connect(port, &SoundDevicePort::nameChanged, this, [ = ](const QString &str) {
         portItem->setText(str);
-    });
-    connect(port, &SoundDevicePort::cardNameChanged, this, [ = ](const QString &str) {
-        portItem->setToolTip(str);
     });
     connect(port, &SoundDevicePort::isActiveChanged, this, [ = ](bool isActive) {
         portItem->setCheckState(isActive ? Qt::CheckState::Checked : Qt::CheckState::Unchecked);


### PR DESCRIPTION
取消声音面板设备悬浮提示

Log: 修复任务栏声音面板中出现异常的悬浮提示的问题
Influence: 任务栏声音面板正常显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4368