### PR TITLE
fix: imcomplete display when dock plugin's tips text is multi-line

### DIFF
--- a/widgets/tipswidget.cpp
+++ b/widgets/tipswidget.cpp
@@ -44,19 +44,25 @@ void TipsWidget::setText(const QString &text)
 
 void TipsWidget::setTextList(const QStringList &textList)
 {
-    m_type = TipsWidget::MultiLine;
-    m_textList = textList;
 
-    int width = 0;
-    int height = 0;
-    for (QString text : m_textList) {
-        width = qMax(width, fontMetrics().horizontalAdvance(text) + 20);
-        height += fontMetrics().boundingRect(text).height();
+    if (textList.size() == 1) {
+        setText(textList.first());
+    } else {
+        int width = 0;
+        int height = 0;
+
+        m_type = TipsWidget::MultiLine;
+        m_textList = textList;
+
+        for (QString &text : m_textList) {
+            width = qMax(width, fontMetrics().horizontalAdvance(text) + 20);
+            height += fontMetrics().boundingRect(text).height();
+        }
+
+        setFixedSize(width + 10, height);
+
+        update();
     }
-
-    setFixedSize(width, height);
-
-    update();
 }
 
 /**
@@ -84,7 +90,7 @@ void TipsWidget::paintEvent(QPaintEvent *event)
             option.setAlignment(Qt::AlignLeft | Qt::AlignVCenter);
         for (QString text : m_textList) {
             int lineHeight = fontMetrics().boundingRect(text).height();
-            painter.drawText(QRect(0, y, rect().width(), lineHeight), text, option);
+            painter.drawText(QRect(10, y, rect().width(), lineHeight), text, option);
             y += lineHeight;
         }
     }


### PR DESCRIPTION
note: rounded corner level is 'large'
Resolve: https://github.com/linuxdeepin/developer-center/issues/4640

Log: 修复当dock插件的提示文本是多行时, 文本显示不全的问题