### PR TITLE
fix: Fix the incomplete display of text when font 20 is scaled to 1.25

### DIFF
--- a/plugins/display/devcollaborationwidget.cpp
+++ b/plugins/display/devcollaborationwidget.cpp
@@ -15,7 +15,7 @@
 #include <QVBoxLayout>
 #include <QStandardItemModel>
 
-#define TITLE_HEIGHT 16
+#define TITLE_HEIGHT 30
 #define ITEM_WIDTH 310
 #define ITEM_HEIGHT 36
 #define LISTVIEW_ITEM_SPACE 5


### PR DESCRIPTION
   修复字体20缩放1.25时的文本显示不全

Log: 调整高度解决文本内容裁切问题
Influence: 电脑协同显示区域
Resolve: https://github.com/linuxdeepin/developer-center/issues/4382
