### PR TITLE
fix: the name of sound device shouldn't be edited

### DIFF
--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -268,6 +268,7 @@ void SoundDevicesWidget::addPort(const SoundDevicePort *port)
     // TODO: get right icon
     portItem->setIcon(QIcon());
     portItem->setText(deviceName);
+    portItem->setEditable(false);
     portItem->setFlags(portItem->flags() & ~Qt::ItemIsSelectable);
     portItem->setTextColorRole(QPalette::BrightText);
     portItem->setData(QVariant::fromValue<const SoundDevicePort *>(port), DeviceObjRole);


### PR DESCRIPTION
We can edit the name of sound device in the dock, it should not be happened. 
Just set the item uneditable.

Log:
close linuxdeepin/developer-center#4752