### PR TITLE
fix: 任务栏声音输出面板输出设备名称可以被修改

### DIFF
--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -273,6 +273,7 @@ void SoundDevicesWidget::addPort(const SoundDevicePort *port)
     portItem->setData(QVariant::fromValue<const SoundDevicePort *>(port), DeviceObjRole);
     portItem->setData(AUDIOPORT, ItemTypeRole);
     portItem->setToolTip(port->cardName());
+    portItem->setEditable(false);
     static QBrush oldBackGroundStyle = portItem->background();
 
     connect(port, &SoundDevicePort::nameChanged, this, [ = ](const QString &str) {


### PR DESCRIPTION
设置任务栏声音输出设备名称不可被修改

Log: 修复任务栏声音输出面板输出设备名称可以被修改的问题
Influence: 任务栏声音输出面板的显示
Resolve: https://github.com/linuxdeepin/developer-center/issues/4752