### PR TITLE
fix: official chrome unable to be identified

### DIFF
--- a/frame/taskmanager/appinfo.cpp
+++ b/frame/taskmanager/appinfo.cpp
@@ -43,9 +43,10 @@ void AppInfo::init(DesktopInfo &info)
     m_fileName = info.getDesktopFilePath();
     m_id = info.getId();
     m_icon = info.getIcon();
-    for (const auto & action : info.getActions()) {
-        m_actions.push_back(action);
-    }
+    m_installed = info.isInstalled();
+    auto actions = info.getActions();
+    std::copy(actions.begin(), actions.end(), std::back_inserter(m_actions));
+
 }
 
 QString AppInfo::genInnerIdWithDesktopInfo(DesktopInfo &info)

--- a/frame/taskmanager/desktopinfo.cpp
+++ b/frame/taskmanager/desktopinfo.cpp
@@ -31,7 +31,9 @@ DesktopInfo::DesktopInfo(const QString &desktopfile)
     if (!desktopFileInfo.isAbsolute()) {
         for (auto dir: QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation)) {
             QString path = dir.append("/").append(desktopfilepath);
-            if (QFile::exists(path)) desktopFileInfo.setFile(path);
+            if (QFile::exists(path)){
+                desktopFileInfo.setFile(path);
+            }
         }
     }
 
@@ -71,6 +73,16 @@ QString DesktopInfo::getDesktopFilePath()
 bool DesktopInfo::isValidDesktop()
 {
     return m_isValid;
+}
+
+bool DesktopInfo::isInstalled()
+{
+    QFileInfo desktopFileInfo(m_desktopFilePath);
+    QString desktopFileName = desktopFileInfo.fileName();
+    static auto applicationDirs = QStandardPaths::standardLocations(QStandardPaths::ApplicationsLocation);
+    return std::any_of(applicationDirs.begin(), applicationDirs.end(), [&desktopFileName](auto applicationDir){
+        return QFile::exists(applicationDir+ '/' + desktopFileName);
+    });
 }
 
 /** if return true, item is shown

--- a/frame/taskmanager/windowidentify.cpp
+++ b/frame/taskmanager/windowidentify.cpp
@@ -379,7 +379,10 @@ AppInfo *WindowIdentify::identifyWindowByRule(TaskManager *_taskmanager, WindowI
 
     if (matchStr.size() > 4 && matchStr.startsWith("id=")) {
         matchStr.remove(0, 3);
-        ret = new AppInfo(matchStr);
+        AppInfo* tmp = new AppInfo(matchStr);
+        // 匹配到了，但是“无效规则“，匹配到程序未安装（优先匹配商店，但是实际程序是原生软件）
+        if (tmp->isValidApp()) ret = tmp;
+        else delete tmp;
     } else if (matchStr == "env") {
         auto process = winInfo->getProcess();
         if (process) {


### PR DESCRIPTION
window_patterns.json used for app in store, and it return cn.google.chrome, whcih is not installed. So, it means that identifyWindowByRule may return a invalid appinfo. Return nullptr if it's invalid appinfo.

implement DesktopInfo::isInstalled

log: fix identifyWindowByRule return a invalid appinfo