### PR TITLE
fix: some app do not display

### DIFF
--- a/frame/controller/dockitemmanager.cpp
+++ b/frame/controller/dockitemmanager.cpp
@@ -64,8 +64,8 @@ DockItemManager::DockItemManager(QObject *parent)
     connect(quickController, &QuickSettingController::pluginLoaderFinished, this, &DockItemManager::onPluginLoadFinished, Qt::QueuedConnection);
 
     // 应用信号
-    connect(m_taskmanager, &TaskManager::entryAdded, this, &DockItemManager::appItemAdded);
-    connect(m_taskmanager, &TaskManager::entryRemoved, this, static_cast<void (DockItemManager::*)(const QString &)>(&DockItemManager::appItemRemoved), Qt::QueuedConnection);
+    connect(m_taskmanager, &TaskManager::entryAdded, this, &DockItemManager::appItemAdded, Qt::DirectConnection);
+    connect(m_taskmanager, &TaskManager::entryRemoved, this, static_cast<void (DockItemManager::*)(const QString &)>(&DockItemManager::appItemRemoved), Qt::DirectConnection);
     connect(m_taskmanager, &TaskManager::serviceRestarted, this, &DockItemManager::reloadAppItems);
     connect(DockSettings::instance(), &DockSettings::showMultiWindowChanged, this, &DockItemManager::onShowMultiWindowChanged);
 


### PR DESCRIPTION
Current entryRemove and entryAdded connection is not thread-safe. Although entryRemove before entryAdded sended, entryRemove slot do later than entryAdded slot, which make added entry (later signal) removed by previous entryRemove signal.

log: make entryRemove and entryAdded connecttion thread-safe.