### PR TITLE
fix: click always activate application in TrayGridWidget

### DIFF
--- a/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/frame/window/tray/widgets/expandiconwidget.cpp
@@ -134,7 +134,7 @@ TrayGridWidget *ExpandIconWidget::popupTrayView()
     TrayModel *trayModel = TrayModel::getIconModel();
     gridParentView->setTrayGridView(trayView);
 
-    gridParentView->setWindowFlags(Qt::FramelessWindowHint | Qt::Tool | Qt::WindowStaysOnTopHint);
+    gridParentView->setWindowFlags(Qt::FramelessWindowHint | Qt::ToolTip | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
     trayView->setModel(trayModel);
     trayView->setItemDelegate(trayDelegate);
     trayView->setSpacing(ITEM_SPACING);


### PR DESCRIPTION
expandiconwidget get focus when click tray, so it will alway activate application because lost focus.

log: set WindowDoesNotAcceptFocus for TrayGridWidget