### PR TITLE
fix: xebmbedtary click get no response in Efficient mode

### DIFF
--- a/frame/window/docktraywindow.cpp
+++ b/frame/window/docktraywindow.cpp
@@ -38,9 +38,9 @@ DockTrayWindow::DockTrayWindow(QWidget *parent)
     , m_dateTimeWidget(new DateTimeDisplayer(true, this))
     , m_systemPuginWidget(new SystemPluginWindow(this))
     , m_quickIconWidget(new QuickPluginWindow(Dock::DisplayMode::Efficient, this))
-    , m_trayView(new TrayGridView(this))
+    , m_trayView(TrayGridView::getDockTrayGridView(this))
     , m_model(TrayModel::getDockModel())
-    , m_delegate(new TrayDelegate(m_trayView, this))
+    , m_delegate(TrayDelegate::getDockTrayDelegate(m_trayView, this))
     , m_toolFrontSpaceWidget(new QWidget(this))
     , m_toolBackSpaceWidget(new QWidget(this))
     , m_dateTimeSpaceWidget(new QWidget(this))
@@ -70,8 +70,14 @@ void DockTrayWindow::setDisplayMode(const Dock::DisplayMode &displayMode)
     moveToolPlugin();
     updateToolWidget();
     // 如果当前模式为高效模式，则设置当前的trayView为其计算位置的参照
-    if (displayMode == Dock::DisplayMode::Efficient)
+    if (displayMode == Dock::DisplayMode::Efficient) {
         ExpandIconWidget::popupTrayView()->setReferGridView(m_trayView);
+        // TODO: reuse QuickPluginWindow, SystemPluginWindow
+        m_mainBoxLayout->addWidget(TrayGridView::getDockTrayGridView());
+    } else {
+        m_mainBoxLayout->removeWidget(TrayGridView::getDockTrayGridView());
+    }
+        
 }
 
 QSize DockTrayWindow::suitableSize(const Dock::Position &position, const int &, const double &) const

--- a/frame/window/tray/tray_delegate.cpp
+++ b/frame/window/tray/tray_delegate.cpp
@@ -30,6 +30,24 @@
 #include <xcb/xcb_icccm.h>
 #include <X11/Xlib.h>
 
+TrayDelegate *TrayDelegate::getDockTrayDelegate(QListView *view, QObject *parent)
+{
+    static TrayDelegate *delegate = nullptr;
+    if (!delegate) {
+        delegate = new TrayDelegate(view, parent);
+    }
+    return delegate;
+}
+
+TrayDelegate *TrayDelegate::getIconTrayDelegate(QListView *view, QObject *parent)
+{
+    static TrayDelegate *delegate = nullptr;
+    if (!delegate) {
+        delegate = new TrayDelegate(view, parent);
+    }
+    return delegate;
+}
+
 TrayDelegate::TrayDelegate(QListView *view, QObject *parent)
     : QStyledItemDelegate(parent)
     , m_position(Dock::Position::Bottom)

--- a/frame/window/tray/tray_delegate.h
+++ b/frame/window/tray/tray_delegate.h
@@ -25,7 +25,9 @@ class TrayDelegate : public QStyledItemDelegate
     Q_OBJECT
 
 public:
-    explicit TrayDelegate(QListView *view, QObject *parent = nullptr);
+    static TrayDelegate *getDockTrayDelegate(QListView *view, QObject *parent = nullptr);
+    static TrayDelegate *getIconTrayDelegate(QListView *view, QObject *parent = nullptr);
+
     void setPositon(Dock::Position position);
 
 Q_SIGNALS:
@@ -44,6 +46,8 @@ protected:
     void paint(QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index) const override;
 
 private:
+    explicit TrayDelegate(QListView *view, QObject *parent = nullptr);
+
     ExpandIconWidget *expandWidget();
     bool isPopupTray() const;
 

--- a/frame/window/tray/tray_gridview.cpp
+++ b/frame/window/tray/tray_gridview.cpp
@@ -19,6 +19,23 @@
 #include <QApplication>
 #include <QDebug>
 #include <QTimer>
+#include <qwidget.h>
+
+TrayGridView *TrayGridView::getDockTrayGridView(QWidget *parent)
+{
+    static TrayGridView *view = nullptr;
+    if (!view)
+        view = new TrayGridView(parent);
+    return view;
+}
+
+TrayGridView *TrayGridView::getIconTrayGridView(QWidget *parent)
+{
+    static TrayGridView *view = nullptr;
+    if (!view)
+        view = new TrayGridView(parent);
+    return view;
+}
 
 TrayGridView::TrayGridView(QWidget *parent)
     : DListView(parent)

--- a/frame/window/tray/tray_gridview.h
+++ b/frame/window/tray/tray_gridview.h
@@ -19,8 +19,9 @@ class TrayGridView : public DListView
     Q_OBJECT
 
 public:
-    explicit TrayGridView(QWidget *parent = Q_NULLPTR);
-
+    static TrayGridView *getDockTrayGridView(QWidget *parent = Q_NULLPTR);
+    static TrayGridView *getIconTrayGridView(QWidget *parent = Q_NULLPTR);
+    
     void setPosition(Dock::Position position);
     Dock::Position position() const;
     QSize suitableSize() const;
@@ -58,6 +59,8 @@ protected:
     bool beginDrag(Qt::DropActions supportedActions);
 
 private:
+    explicit TrayGridView(QWidget *parent = Q_NULLPTR);
+
     void initUi();
     void createAnimation(const int pos, const bool moveNext, const bool isLastAni);
     const QModelIndex getIndexFromPos(QPoint currentPoint) const;

--- a/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/frame/window/tray/widgets/expandiconwidget.cpp
@@ -129,8 +129,8 @@ TrayGridWidget *ExpandIconWidget::popupTrayView()
         return gridParentView;
 
     gridParentView = new TrayGridWidget(nullptr);
-    TrayGridView *trayView = new TrayGridView(gridParentView);
-    TrayDelegate *trayDelegate = new TrayDelegate(trayView, trayView);
+    TrayGridView *trayView = TrayGridView::getIconTrayGridView(gridParentView);
+    TrayDelegate *trayDelegate = TrayDelegate::getIconTrayDelegate(trayView, trayView);
     TrayModel *trayModel = TrayModel::getIconModel();
     gridParentView->setTrayGridView(trayView);
 

--- a/frame/window/traymanagerwindow.cpp
+++ b/frame/window/traymanagerwindow.cpp
@@ -45,9 +45,9 @@ TrayManagerWindow::TrayManagerWindow(QWidget *parent)
     , m_dateTimeWidget(new DateTimeDisplayer(false, m_appPluginDatetimeWidget))
     , m_appPluginLayout(new QBoxLayout(QBoxLayout::Direction::LeftToRight, this))
     , m_mainLayout(new QBoxLayout(QBoxLayout::Direction::LeftToRight, this))
-    , m_trayView(new TrayGridView(this))
+    , m_trayView(TrayGridView::getDockTrayGridView(this))
     , m_model(TrayModel::getDockModel())
-    , m_delegate(new TrayDelegate(m_trayView, m_trayView))
+    , m_delegate(TrayDelegate::getDockTrayDelegate(m_trayView, m_trayView))
     , m_position(Dock::Position::Bottom)
     , m_displayMode(Dock::DisplayMode::Fashion)
     , m_splitLine(new QLabel(m_appPluginDatetimeWidget))
@@ -151,6 +151,12 @@ void TrayManagerWindow::setDisplayMode(Dock::DisplayMode displayMode)
     if (displayMode == Dock::DisplayMode::Fashion) {
         ExpandIconWidget::popupTrayView()->setReferGridView(m_trayView);
         updateItemLayout(m_windowFashionSize);
+        // TODO: reuse QuickPluginWindow, SystemPluginWindow
+        m_appPluginLayout->addWidget(TrayGridView::getDockTrayGridView());
+        m_appPluginLayout->addWidget(m_quickIconWidget);
+    } else {
+        m_appPluginLayout->removeWidget(TrayGridView::getDockTrayGridView());
+        m_appPluginLayout->removeWidget(m_quickIconWidget);
     }
 }
 


### PR DESCRIPTION
The tray in fashion mode is not the same object as the tray in efficient mode, and only one xembedtray is vaild, so there will be a contention between the two. The latter xembedtray who call reparent() will be the vaild one. So drag from expandiconwidget, the xembed tray click in the efficient mode get no response while the tray click get response when switching from the fashion mode.

log: make tray(both fashion and efficient mode) to be one object