### PR TITLE
fix: click preview container not active window

### DIFF
--- a/frame/item/appitem.cpp
+++ b/frame/item/appitem.cpp
@@ -755,7 +755,7 @@ void AppItem::showPreview()
     m_appPreviewTips->setWindowInfos(m_windowInfos, m_itemEntry->getAllowedClosedWindowIds().toList());
     m_appPreviewTips->updateLayoutDirection(DockPosition);
 
-    connect(m_appPreviewTips, &PreviewContainer::requestActivateWindow, this, &AppItem::requestActivateWindow, Qt::QueuedConnection);
+    connect(m_appPreviewTips, &PreviewContainer::requestActivateWindow, this, &AppItem::activeWindow, Qt::QueuedConnection);
     connect(m_appPreviewTips, &PreviewContainer::requestPreviewWindow, this, &AppItem::requestPreviewWindow, Qt::QueuedConnection);
     connect(m_appPreviewTips, &PreviewContainer::requestCancelPreviewWindow, this, &AppItem::requestCancelPreview);
     connect(m_appPreviewTips, &PreviewContainer::requestHidePopup, this, &AppItem::hidePopup);

--- a/frame/item/components/previewcontainer.cpp
+++ b/frame/item/components/previewcontainer.cpp
@@ -255,7 +255,7 @@ void PreviewContainer::onSnapshotClicked(const WId wid)
     Q_EMIT requestActivateWindow(wid);
     m_needActivate = true;
     m_waitForShowPreviewTimer->stop();
-    requestHidePopup();
+    Q_EMIT requestHidePopup();
 }
 
 void PreviewContainer::previewEntered(const WId wid)


### PR DESCRIPTION
it connect to a empty signal

Log: