### PR TITLE
fix: Can't hide when DockPopupWindow deactivate

### DIFF
--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -208,6 +208,7 @@ bool DockPopupWindow::eventFilter(QObject *o, QEvent *e)
         }
         break;
     }
+    case QEvent::WindowDeactivate:
     case QEvent::Hide: {
         this->hide();
         break;


### PR DESCRIPTION
  We hide the popupwindow when receiving QEvent::WindowDeactivate.

Issue: https://github.com/linuxdeepin/developer-center/issues/5405