### PR TITLE
fix: coredump empty tray when switch postion

### DIFF
--- a/frame/window/tray/tray_gridview.cpp
+++ b/frame/window/tray/tray_gridview.cpp
@@ -52,7 +52,12 @@ TrayGridView::TrayGridView(QWidget *parent)
 
 void TrayGridView::setPosition(Dock::Position position)
 {
+    if (m_positon == position) {
+        return;
+    }
     m_positon = position;
+    setOrientation(m_positon == Dock::Position::Top || m_positon == Dock::Position::Bottom ?
+        QListView::Flow::LeftToRight : QListView::Flow::TopToBottom, false);
 }
 
 Dock::Position TrayGridView::position() const

--- a/frame/window/traymanagerwindow.cpp
+++ b/frame/window/traymanagerwindow.cpp
@@ -128,11 +128,6 @@ void TrayManagerWindow::setPositon(Dock::Position position)
 
     m_position = position;
 
-    if (position == Dock::Position::Top || position == Dock::Position::Bottom)
-        m_trayView->setOrientation(QListView::Flow::LeftToRight, false);
-    else
-        m_trayView->setOrientation(QListView::Flow::TopToBottom, false);
-
     TrayDelegate *delegate = static_cast<TrayDelegate *>(m_trayView->itemDelegate());
     delegate->setPositon(position);
 


### PR DESCRIPTION
Fashion mode and Efficent mode has same one tray, when tray is empty and update orientation will cause endless reseize event which case dock stack boom

log: move TrayGridView Orientation update into TrayGridView