### PR TITLE
fix: displayplugin disappear when monitor count changed

### DIFF
--- a/plugins/display/brightnessadjwidget.cpp
+++ b/plugins/display/brightnessadjwidget.cpp
@@ -12,13 +12,14 @@
 
 const int ItemSpacing = 5;
 
-BrightnessAdjWidget::BrightnessAdjWidget(QWidget *parent)
+BrightnessAdjWidget::BrightnessAdjWidget(BrightnessModel *model, QWidget *parent)
     : QWidget(parent)
     , m_mainLayout(new QVBoxLayout(this))
-    , m_brightnessModel(new BrightnessModel(this))
+    , m_brightnessModel(model)
 {
     m_mainLayout->setMargin(0);
     m_mainLayout->setSpacing(ItemSpacing);
+    connect(m_brightnessModel, &BrightnessModel::monitorChanged, this, &BrightnessAdjWidget::loadBrightnessItem);
 
     loadBrightnessItem();
 }
@@ -27,6 +28,11 @@ void BrightnessAdjWidget::loadBrightnessItem()
 {
     QList<BrightMonitor *> monitors = m_brightnessModel->monitors();
     int itemHeight = monitors.count() > 1 ? 56 : 30;
+
+    // 清理之前的widget
+    while(m_mainLayout->count() > 0) {
+        m_mainLayout->takeAt(0)->widget()->deleteLater();
+    }
 
     for (BrightMonitor *monitor : monitors) {
         SliderContainer *sliderContainer = new SliderContainer(this);
@@ -54,5 +60,6 @@ void BrightnessAdjWidget::loadBrightnessItem()
 
     QMargins margins = this->contentsMargins();
     setFixedHeight(margins.top() + margins.bottom() + monitors.count() * itemHeight + monitors.count() * ItemSpacing);
+    Q_EMIT sizeChanged();
 }
 

--- a/plugins/display/brightnessadjwidget.h
+++ b/plugins/display/brightnessadjwidget.h
@@ -19,9 +19,12 @@ class BrightnessAdjWidget : public QWidget
 {
     Q_OBJECT
 public:
-    explicit BrightnessAdjWidget(QWidget *parent = nullptr);
+    explicit BrightnessAdjWidget(BrightnessModel *model, QWidget *parent = nullptr);
 
-private:
+Q_SIGNALS:
+    void sizeChanged();
+
+private Q_SLOTS:
     void loadBrightnessItem();
 
 private:

--- a/plugins/display/brightnessmodel.cpp
+++ b/plugins/display/brightnessmodel.cpp
@@ -11,6 +11,7 @@
 #include <QDebug>
 #include <QApplication>
 #include <QScreen>
+#include <qobjectdefs.h>
 
 static const QString serviceName("org.deepin.dde.Display1");
 static const QString servicePath("/org/deepin/dde/Display1");
@@ -88,14 +89,10 @@ void BrightnessModel::onPropertyChanged(const QDBusMessage &msg)
         if (defaultMonitor)
             Q_EMIT primaryChanged(defaultMonitor);
     } else if (changedProps.contains("Monitors")) {
-        int oldSize = m_monitor.size();
         qDeleteAll(m_monitor);
-        m_monitor = readMonitors(changedProps.value("Monitors").value<QList<QDBusObjectPath>>());
-        if (oldSize == 1 && m_monitor.size() == 0) {
-            Q_EMIT screenVisibleChanged(false);
-        } else if (oldSize == 0 && m_monitor.size() == 1) {
-            Q_EMIT screenVisibleChanged(true);
-        }
+        QDBusInterface dbusInter(serviceName, servicePath, serviceInterface, QDBusConnection::sessionBus());
+        m_monitor = readMonitors(dbusInter.property("Monitors").value<QList<QDBusObjectPath>>());
+        Q_EMIT monitorChanged();
     }
 }
 

--- a/plugins/display/brightnessmodel.h
+++ b/plugins/display/brightnessmodel.h
@@ -26,7 +26,7 @@ public:
 
 Q_SIGNALS:
     void primaryChanged(BrightMonitor *);
-    void screenVisibleChanged(bool);
+    void monitorChanged();
     void monitorLightChanged();
 
 protected Q_SLOTS:

--- a/plugins/display/displayplugin.cpp
+++ b/plugins/display/displayplugin.cpp
@@ -49,7 +49,7 @@ void DisplayPlugin::init(PluginProxyInterface *proxyInter)
     m_model.reset(new BrightnessModel);
     m_displayWidget.reset(new BrightnessWidget(m_model.data()));
     m_displayWidget->setFixedHeight(60);
-    m_displaySettingWidget.reset(new DisplaySettingWidget);
+    m_displaySettingWidget.reset(new DisplaySettingWidget(m_model.data()));
 
     if (m_model->monitors().size() > 0)
         m_proxyInter->itemAdded(this, pluginName());
@@ -60,8 +60,8 @@ void DisplayPlugin::init(PluginProxyInterface *proxyInter)
     connect(m_displaySettingWidget.data(), &DisplaySettingWidget::requestHide, this, [ this ] {
         m_proxyInter->requestSetAppletVisible(this, QUICK_ITEM_KEY, false);
     });
-    connect(m_model.data(), &BrightnessModel::screenVisibleChanged, this, [ this ](bool visible) {
-        if (visible)
+    connect(m_model.data(), &BrightnessModel::monitorChanged, this, [ this ]() {
+        if (m_model->monitors().size() > 0)
             m_proxyInter->itemAdded(this, pluginName());
         else
             m_proxyInter->itemRemoved(this, pluginName());

--- a/plugins/display/displaysettingwidget.cpp
+++ b/plugins/display/displaysettingwidget.cpp
@@ -4,7 +4,6 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "displaysettingwidget.h"
-#include "brightnessadjwidget.h"
 #include "devcollaborationwidget.h"
 
 #include <QPushButton>
@@ -14,9 +13,9 @@
 
 const int ItemSpacing = 10;
 
-DisplaySettingWidget::DisplaySettingWidget(QWidget *parent)
+DisplaySettingWidget::DisplaySettingWidget(BrightnessModel *model, QWidget *parent)
     : QWidget(parent)
-    , m_brightnessAdjWidget(new BrightnessAdjWidget(this))
+    , m_brightnessAdjWidget(new BrightnessAdjWidget(model, this))
     , m_collaborationWidget(new DevCollaborationWidget(this))
     , m_settingBtn(new QPushButton(tr("Multi-Screen Collaboration"), this))
 {
@@ -47,6 +46,8 @@ void DisplaySettingWidget::initUI()
 
     resizeWidgetHeight();
     connect(m_collaborationWidget, &DevCollaborationWidget::sizeChanged,
+            this, &DisplaySettingWidget::resizeWidgetHeight);
+    connect(m_brightnessAdjWidget, &BrightnessAdjWidget::sizeChanged,
             this, &DisplaySettingWidget::resizeWidgetHeight);
 }
 

--- a/plugins/display/displaysettingwidget.h
+++ b/plugins/display/displaysettingwidget.h
@@ -6,6 +6,8 @@
 #ifndef DISPLAY_SETTING_WIDGET_H
 #define DISPLAY_SETTING_WIDGET_H
 
+#include "brightnessadjwidget.h"
+
 #include <QWidget>
 
 class QPushButton;
@@ -21,7 +23,7 @@ class DisplaySettingWidget : public QWidget
     Q_OBJECT
 
 public:
-    explicit DisplaySettingWidget(QWidget *parent = nullptr);
+    explicit DisplaySettingWidget(BrightnessModel *model, QWidget *parent = nullptr);
 
 Q_SIGNALS:
     void requestHide();


### PR DESCRIPTION
changedProps.vale get a empty monitors list, and BrightnessAdjWidget not update  monitor SliderContainer count

log: fix displayplugin disappear