### PR TITLE
 fix: brightness silder cannot scroll when value is 28 or 56

### DIFF
--- a/plugins/display/brightnessmodel.cpp
+++ b/plugins/display/brightnessmodel.cpp
@@ -175,7 +175,7 @@ void BrightMonitor::onPropertyChanged(const QDBusMessage &msg)
 
     QVariantMap changedProps = qdbus_cast<QVariantMap>(arguments.at(1).value<QDBusArgument>());
     if (changedProps.contains("Brightness")) {
-        int brightness = static_cast<int>(changedProps.value("Brightness").value<double>() * 100);
+        int brightness = QVariant(changedProps.value("Brightness").value<double>() * 100).toInt();
         if (brightness != m_brightness) {
             m_brightness = brightness;
             Q_EMIT brightnessChanged(brightness);


### PR DESCRIPTION
double 0.29 * 100 then cast to init, it is 28

Log: