### PR TITLE
feat: use system battery icon first

### DIFF
--- a/plugins/bluetooth/componments/bluetoothadapteritem.cpp
+++ b/plugins/bluetooth/componments/bluetoothadapteritem.cpp
@@ -16,6 +16,7 @@
 #include <DListView>
 #include <DSpinner>
 #include <DGuiApplicationHelper>
+#include <DIconTheme>
 
 #include <QBoxLayout>
 #include <QStandardItemModel>
@@ -115,7 +116,9 @@ QIcon BluetoothDeviceItem::getBatteryIcon(int percentage)
         percentageStr = "unknow";
     }
 
-    return QIcon::fromTheme(QString("battery-%1-symbolic").arg(percentageStr));
+    QString iconName = QString("battery-%1-symbolic").arg(percentageStr);
+    QIcon qrcIcon = DIconTheme::findQIcon(iconName, DIconTheme::DontFallbackToQIconFromTheme);
+    return DIconTheme::findQIcon(iconName, qrcIcon, DIconTheme::IgnoreBuiltinIcons);
 
 }
 

--- a/plugins/power/powerstatuswidget.cpp
+++ b/plugins/power/powerstatuswidget.cpp
@@ -95,9 +95,6 @@ QPixmap PowerStatusWidget::getBatteryIcon(int themeType)
                   .arg(plugged ? "plugged-symbolic" : "symbolic");
     }
 
-    if (themeType == DGuiApplicationHelper::ColorType::LightType)
-        iconStr.append(PLUGIN_MIN_ICON_NAME);
-
     const auto ratio = devicePixelRatioF();
     QSize pixmapSize = QCoreApplication::testAttribute(Qt::AA_UseHighDpiPixmaps) ? QSize(20, 20) : (QSize(20, 20) * ratio);
     QPixmap pix = QIcon::fromTheme(iconStr, QIcon::fromTheme(":/batteryicons/resources/batteryicons/" + iconStr + ".svg")).pixmap(pixmapSize);


### PR DESCRIPTION
Log:

Icon 主题已经修复了，所以不需要在亮色强制用暗色了，
电源图标也用默认的即可