### PR TITLE
 fix: dcc dock plugin icon pixelated again

### DIFF
--- a/frame/dbus/dbusdockadaptors.cpp
+++ b/frame/dbus/dbusdockadaptors.cpp
@@ -326,7 +326,7 @@ QIcon DBusDockAdaptors::getSettingIcon(PluginsItemInterface *plugin, QSize &pixm
 {
     auto iconSize = [](const QIcon &icon) {
         QList<QSize> iconSizes = icon.availableSizes();
-        if (iconSizes.size() > 0)
+        if (iconSizes.size() > 0 && !iconSizes[0].isNull() )
             return iconSizes[0];
 
         return defaultIconSize;

--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -8,6 +8,7 @@
 
 #include <DWindowManagerHelper>
 #include <DDBusSender>
+#include <QPainter>
 
 #include <QIcon>
 
@@ -141,8 +142,17 @@ void MultitaskingPlugin::invokedMenuItem(const QString &itemKey, const QString &
 
 QIcon MultitaskingPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-    if (dockPart == DockPart::DCCSetting)
-        return  QIcon::fromTheme("dcc-multitasking-view",QIcon(":/icons/icons/dcc-multitasking-view.svg"));
+    if (dockPart == DockPart::DCCSetting) {
+        auto icon = QIcon::fromTheme("dcc-multitasking-view", QIcon(":/icons/dcc-multitasking-view.svg"));
+        QPixmap pixmap = icon.pixmap(QSize(18, 18));
+        if (themeType == DGuiApplicationHelper::ColorType::LightType)
+            return pixmap;
+
+        QPainter pa(&pixmap);
+        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        pa.fillRect(pixmap.rect(), Qt::white);
+        return pixmap;
+    }
 
     return QIcon();
 }

--- a/plugins/show-desktop/CMakeLists.txt
+++ b/plugins/show-desktop/CMakeLists.txt
@@ -16,7 +16,7 @@ find_package(DtkWidget REQUIRED)
 pkg_check_modules(XCB_LIBS REQUIRED IMPORTED_TARGET xcursor)
 
 add_definitions("${QT_DEFINITIONS} -DQT_PLUGIN")
-add_library(${PLUGIN_NAME} SHARED ${SRCS})
+add_library(${PLUGIN_NAME} SHARED ${SRCS} resource.qrc)
 set_target_properties(${PLUGIN_NAME} PROPERTIES LIBRARY_OUTPUT_DIRECTORY ../)
 target_include_directories(${PLUGIN_NAME} PUBLIC ${DtkWidget_INCLUDE_DIRS} ../../interfaces)
 target_link_libraries(${PLUGIN_NAME} PRIVATE

--- a/plugins/show-desktop/showdesktopplugin.cpp
+++ b/plugins/show-desktop/showdesktopplugin.cpp
@@ -4,11 +4,13 @@
 // SPDX-License-Identifier: LGPL-3.0-or-later
 
 #include "showdesktopplugin.h"
+#include "imageutil.h"
 #include "../widgets/tipswidget.h"
 
 #include <QIcon>
 #include <QDebug>
 #include <DDBusSender>
+#include <QPainter>
 
 using namespace Dock;
 ShowDesktopPlugin::ShowDesktopPlugin(QObject *parent)
@@ -121,9 +123,17 @@ void ShowDesktopPlugin::refreshIcon(const QString &itemKey)
 
 QIcon ShowDesktopPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-
     if (dockPart == DockPart::DCCSetting) {
-        return QIcon::fromTheme("dcc-show-desktop", QIcon(":/icons/icons/dcc-show-desktop.svg"));
+        auto loadsvg = []{ return ImageUtil::loadSvg(":/icons/dcc-show-desktop.svg", QSize(18, 18));};
+        auto icon = QIcon::fromTheme("dcc-show-desktop", loadsvg());
+        QPixmap pixmap = icon.pixmap(QSize(18, 18));
+        if (themeType == DGuiApplicationHelper::ColorType::LightType)
+            return pixmap;
+
+        QPainter pa(&pixmap);
+        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        pa.fillRect(pixmap.rect(), Qt::white);
+        return pixmap;
     }
 
     return QIcon();

--- a/plugins/shutdown/CMakeLists.txt
+++ b/plugins/shutdown/CMakeLists.txt
@@ -4,7 +4,11 @@ set(PLUGIN_NAME "shutdown")
 project(${PLUGIN_NAME})
 
 # Sources files
-file(GLOB_RECURSE SRCS "*.h" "*.cpp" "../../widgets/tipswidget.h" "../../widgets/tipswidget.cpp")
+file(GLOB_RECURSE SRCS "*.h" "*.cpp"
+    "../../widgets/tipswidget.h"
+    "../../widgets/tipswidget.cpp"
+    "../../frame/util/imageutil.cpp"
+)
 
 find_package(PkgConfig REQUIRED)
 find_package(Qt5Widgets REQUIRED)

--- a/plugins/shutdown/shutdownplugin.cpp
+++ b/plugins/shutdown/shutdownplugin.cpp
@@ -275,10 +275,11 @@ void ShutdownPlugin::setSortKey(const QString &itemKey, const int order)
 QIcon ShutdownPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
     if (dockPart == DockPart::DCCSetting) {
+        QString iconFile(":/icons/resources/icons/dcc_shutdown.svg");
+        auto pixmap = ImageUtil::loadSvg(iconFile, QSize(18, 18));
         if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return QIcon(":/icons/resources/icons/dcc_shutdown.svg");
+            return pixmap;
 
-        QPixmap pixmap(":/icons/resources/icons/dcc_shutdown.svg");
         QPainter pa(&pixmap);
         pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
         pa.fillRect(pixmap.rect(), Qt::white);

--- a/plugins/sound/sounddeviceswidget.cpp
+++ b/plugins/sound/sounddeviceswidget.cpp
@@ -530,7 +530,15 @@ QPixmap SoundDevicesWidget::pixmap(DGuiApplicationHelper::ColorType colorType, i
     else if (volmue > maxVolmue * 1 / 3)
         volumeString = "medium";
     else
-        volumeString = "low";;
+        volumeString = "low";
 
-    return QIcon::fromTheme(QString("audio-volume-%1-symbolic").arg(volumeString)).pixmap(iconWidth, iconHeight);
+    auto pixmap = QIcon::fromTheme(QString("audio-volume-%1-symbolic").arg(volumeString)).pixmap(iconWidth, iconHeight);
+
+    if (colorType == DGuiApplicationHelper::ColorType::LightType)
+        return pixmap;
+
+    QPainter pa(&pixmap);
+    pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
+    pa.fillRect(pixmap.rect(), Qt::white);
+    return pixmap;
 }

--- a/plugins/trash/trashplugin.cpp
+++ b/plugins/trash/trashplugin.cpp
@@ -5,6 +5,7 @@
 
 #include "trashplugin.h"
 #include "../../widgets/tipswidget.h"
+#include "imageutil.h"
 
 #include <DApplication>
 #include <DDesktopServices>
@@ -174,10 +175,10 @@ void TrashPlugin::pluginSettingsChanged()
 QIcon TrashPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
     if (dockPart == DockPart::DCCSetting) {
+        auto pixmap = ImageUtil::loadSvg(":/icons/dcc_trash.svg", QSize(18, 18));
         if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return QIcon(":/icons/dcc_trash.svg");
+            return pixmap;
 
-        QPixmap pixmap(":/icons/dcc_trash.svg");
         QPainter pa(&pixmap);
         pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
         pa.fillRect(pixmap.rect(), Qt::white);


### PR DESCRIPTION
- 部分图片路径写错
- 资源图片直接加到qicon中，qicon.availableSizes[0]={0, 0}
- 部分插件没有适配主题颜色

Issue: https://github.com/linuxdeepin/developer-center/issues/5682