### PR TITLE
fix: mainwindow hide when popup opens

### DIFF
--- a/frame/taskmanager/taskmanager.cpp
+++ b/frame/taskmanager/taskmanager.cpp
@@ -50,6 +50,7 @@ TaskManager::TaskManager(QObject *parent)
  , m_hideState(HideState::Unknown)
  , m_ddeLauncherVisible(false)
  , m_trayGridWidgetVisible(false)
+ , m_popupVisible(false)
  , m_entries(new Entries(this))
  , m_windowIdentify(new WindowIdentify(this))
  , m_dbusHandler(new DBusHandler(this))
@@ -248,7 +249,7 @@ bool TaskManager::shouldShowOnDock(WindowInfoBase *info)
  */
 void TaskManager::setDdeLauncherVisible(bool visible)
 {
-    m_trayGridWidgetVisible = visible;
+    m_ddeLauncherVisible = visible;
 }
 
 /**
@@ -257,7 +258,12 @@ void TaskManager::setDdeLauncherVisible(bool visible)
  */
 void TaskManager::setTrayGridWidgetVisible(bool visible)
 {
-    m_ddeLauncherVisible = visible;
+    m_trayGridWidgetVisible = visible;
+}
+
+void TaskManager::setPopupVisible(bool visible)
+{
+    m_popupVisible = visible;
 }
 
 /**
@@ -849,7 +855,7 @@ Entry *TaskManager::getDockedEntryByDesktopFile(const QString &desktopFile)
  */
 bool TaskManager::shouldHideOnSmartHideMode()
 {
-    if (!m_activeWindow || m_ddeLauncherVisible || m_trayGridWidgetVisible)
+    if (!m_activeWindow || m_ddeLauncherVisible || m_trayGridWidgetVisible || m_popupVisible)
         return false;
 
     if (!m_isWayland) {
@@ -949,7 +955,7 @@ QVector<XWindow> TaskManager::getActiveWinGroup(XWindow xid)
  */
 void TaskManager::updateHideState(bool delay)
 {
-    if (m_ddeLauncherVisible || m_trayGridWidgetVisible) {
+    if (m_ddeLauncherVisible || m_trayGridWidgetVisible || m_popupVisible) {
         setPropHideState(HideState::Show);
         return;
     }

--- a/frame/taskmanager/taskmanager.h
+++ b/frame/taskmanager/taskmanager.h
@@ -41,6 +41,7 @@ public:
     bool shouldShowOnDock(WindowInfoBase *info);
     void setDdeLauncherVisible(bool visible);
     void setTrayGridWidgetVisible(bool visible);
+    void setPopupVisible(bool visible);
     QString getWMName();
     void setWMName(QString name);
     void setPropHideState(HideState state);
@@ -177,6 +178,7 @@ private:
     ForceQuitAppMode m_forceQuitAppStatus; // 强制退出应用状态
     bool m_ddeLauncherVisible;
     bool m_trayGridWidgetVisible;
+    bool m_popupVisible;
 
     Entries *m_entries;   // 所有应用实例
     X11Manager *m_x11Manager;     // X11窗口管理

--- a/frame/util/dockpopupwindow.cpp
+++ b/frame/util/dockpopupwindow.cpp
@@ -9,6 +9,7 @@
 #include "dbusutil.h"
 #include "dockscreen.h"
 #include "displaymanager.h"
+#include "taskmanager/taskmanager.h"
 
 #include <QScreen>
 #include <QApplication>
@@ -172,12 +173,14 @@ void DockPopupWindow::showEvent(QShowEvent *e)
         Utils::updateCursor(this);
     }
 
+    TaskManager::instance()->setPopupVisible(true);
     QTimer::singleShot(1, this, &DockPopupWindow::ensureRaised);
 }
 
 void DockPopupWindow::hideEvent(QHideEvent *event)
 {
     m_extendWidget = nullptr;
+    TaskManager::instance()->setPopupVisible(false);
     Dtk::Widget::DBlurEffectWidget::hideEvent(event);
 }
 


### PR DESCRIPTION
MainWindow should not hide when popup opens and the focus is still on dock even if HideMode is AlwaysHide. Let popup block hiding of mainwindow.

Log: fix mainwindow hide when popup opens
Issue: https://github.com/linuxdeepin/developer-center/issues/4970