### PR TITLE
fix: cross-thread parenting failure

### DIFF
--- a/plugins/notification/notification.cpp
+++ b/plugins/notification/notification.cpp
@@ -29,7 +29,7 @@ Notification::Notification(QWidget *parent)
     setMinimumSize(PLUGIN_BACKGROUND_MIN_SIZE, PLUGIN_BACKGROUND_MIN_SIZE);
     connect(this, &Notification::dndModeChanged, this, &Notification::refreshIcon);
     QtConcurrent::run([this](){
-        m_dbus = new QDBusInterface("org.deepin.dde.Notification1", "/org/deepin/dde/Notification1", "org.deepin.dde.Notification1", QDBusConnection::sessionBus(), this);
+        m_dbus.reset(new QDBusInterface("org.deepin.dde.Notification1", "/org/deepin/dde/Notification1", "org.deepin.dde.Notification1"));
         // Refresh icon for the first time, cause org.deepin.dde.Notification1 might depend on dock's DBus,
         // we should not call org.deepin.dde.Notification1 in the main thread before dock's dbus is initialized.
         // Just refresh icon in the other thread.

--- a/plugins/notification/notification.h
+++ b/plugins/notification/notification.h
@@ -37,7 +37,7 @@ protected:
 
 private:
     QIcon m_icon;
-    QDBusInterface *m_dbus;
+    QScopedPointer<QDBusInterface> m_dbus;
     bool m_dndMode;
 };
 


### PR DESCRIPTION
Cannot create a child in another thread. Do not use object tree, use QScopedPointer to manage life scope.

Log: fix cross-thread parenting failure