### PR TITLE
fix: quickpanel icon not follow theme

### DIFF
--- a/plugins/pluginmanager/standardquickitem.cpp
+++ b/plugins/pluginmanager/standardquickitem.cpp
@@ -13,6 +13,7 @@
 #include <QVBoxLayout>
 #include <QHBoxLayout>
 #include <QMouseEvent>
+#include <DApplication>
 
 static constexpr int ICONHEIGHT = 24;
 static constexpr int ICONWIDTH = 24;
@@ -26,6 +27,14 @@ StandardQuickItem::StandardQuickItem(PluginsItemInterface *const pluginInter, co
     , m_needPaint(true)
 {
     initUi();
+    auto app = static_cast<DApplication* >(qApp);
+    if (!app) {
+        return;
+    }
+    connect(app, &DApplication::iconThemeChanged, this, [this] {
+        m_needPaint = true;
+        doUpdate();
+    });
 }
 
 StandardQuickItem::~StandardQuickItem()


### PR DESCRIPTION
battery should use fallback icon when in dark theme, because it will always find the light theme.

update quickItem when theme changed

Log: