### PR TITLE
fix: dock wakeup area not changed

### DIFF
--- a/frame/util/multiscreenworker.cpp
+++ b/frame/util/multiscreenworker.cpp
@@ -181,6 +181,7 @@ void MultiScreenWorker::onPositionChanged(int position)
     qDebug() << "position change from: " << lastPos << " to: " << position;
 #endif
     m_position = static_cast<Position>(position);
+    Q_EMIT positionChanged(m_position);
 
     if (m_hideMode == HideMode::KeepHidden || (m_hideMode == HideMode::SmartHide && m_hideState == HideState::Hide)) {
         // 这种情况切换位置,任务栏不需要显示


### PR DESCRIPTION
When dock is hidden, position change through DBus will not change frontend rect, thus not update wakeup area. This is because position in WindowManager is not changed. Emit positionChanged signal in MultiScreenWorker.

Log: fix dock wakeup area not changed
Issue: https://github.com/linuxdeepin/developer-center/issues/5831