### PR TITLE
fix: bluetooth quick-trays item icon tweak

### DIFF
--- a/plugins/bluetooth/bluetoothmainwidget.cpp
+++ b/plugins/bluetooth/bluetoothmainwidget.cpp
@@ -24,7 +24,7 @@ DWIDGET_USE_NAMESPACE
 BluetoothMainWidget::BluetoothMainWidget(AdaptersManager *adapterManager, QWidget *parent)
     : QWidget(parent)
     , m_adapterManager(adapterManager)
-    , m_iconWidget(new QWidget(this))
+    , m_iconButton(new DIconButton(this))
     , m_nameLabel(new QLabel(this))
     , m_stateLabel(new QLabel(this))
     , m_expandLabel(new QLabel(this))
@@ -40,67 +40,7 @@ BluetoothMainWidget::~BluetoothMainWidget()
 
 bool BluetoothMainWidget::eventFilter(QObject *watcher, QEvent *event)
 {
-    if (watcher == m_iconWidget) {
-        switch (event->type()) {
-        case QEvent::Paint: {
-            QPainter painter(m_iconWidget);
-            // 在区域最中间绘制
-            QRect iconRect = m_iconWidget->rect();
-            int size = qMin(iconRect.height(), iconRect.width());
-            QPoint ptCenter(iconRect.center());
-            painter.setRenderHints(QPainter::Antialiasing | QPainter::SmoothPixmapTransform);
-            // 填充原型路径
-            QPainterPath path;
-            path.addEllipse(ptCenter, size / 2 - 1, size / 2 - 1);
-            // 设置黑色背景色
-            QColor backColor = (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType ? Qt::black : Qt::white);
-            if (DGuiApplicationHelper::instance()->themeType() == DGuiApplicationHelper::ColorType::LightType)
-                backColor.setAlphaF(m_mouseEnter ? 0.2 : 0.1);
-            else
-                backColor.setAlphaF(m_mouseEnter ? 0.1 : 0.2);
-            painter.setBrush(backColor);
-            painter.fillPath(path, backColor);
-            // 添加图标
-            bool blueStatus = isOpen();
-            QPixmap pixmap(bluetoothIcon(blueStatus));
-            if (blueStatus) {
-                QPainter pa(&pixmap);
-                pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-                pa.fillRect(pixmap.rect(), qApp->palette().highlight());
-            }
-            painter.drawPixmap(QPoint(ptCenter.x() - pixmap.size().width() / 2, ptCenter.y() - pixmap.size().height() / 2), pixmap);
-            return true;
-        }
-        case QEvent::Enter: {
-            m_mouseEnter = true;
-            m_iconWidget->update();
-            break;
-        }
-        case QEvent::Leave: {
-            m_mouseEnter = false;
-            m_iconWidget->update();
-            break;
-        }
-        case QEvent::MouseButtonRelease: {
-            QMouseEvent *mouseevent = static_cast<QMouseEvent *>(event);
-            if (mouseevent->button() != Qt::LeftButton) {
-                return QWidget::eventFilter(watcher, event);
-            }
-            bool status = !(isOpen());
-            for (const Adapter *adapter : m_adapterManager->adapters())
-                m_adapterManager->setAdapterPowered(adapter, status);
-
-            return true;
-        }
-        default:
-            break;
-        }
-
-        return QWidget::eventFilter(watcher, event);
-    }
-    // else watcher != m_iconWidget
-
-    if (event->type() == QEvent::MouseButtonRelease) {
+    if (watcher != m_iconButton && event->type() == QEvent::MouseButtonRelease) {
         Q_EMIT requestExpand();
         return true;
     }
@@ -110,6 +50,9 @@ bool BluetoothMainWidget::eventFilter(QObject *watcher, QEvent *event)
     if (watcher == m_stateLabel && event->type() == QEvent::Resize) {
         m_stateLabel->setText(QFontMetrics(m_stateLabel->font()).elidedText(m_stateLabel->text(), Qt::TextElideMode::ElideRight, m_stateLabel->width()));
     }
+    if (watcher == m_iconButton && event->type() == QEvent::PaletteChange) {
+        onPaletteChanged();
+    }
     return QWidget::eventFilter(watcher, event);
 }
 
@@ -117,7 +60,15 @@ void BluetoothMainWidget::initUi()
 {
     QHBoxLayout *mainLayout = new QHBoxLayout(this);
     // 添加左侧的图标
-    m_iconWidget->setFixedWidth(36);
+    m_iconButton->setEnabledCircle(true);
+    m_iconButton->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);
+    m_iconButton->setFocusPolicy(Qt::FocusPolicy::TabFocus);
+    m_iconButton->setIconSize({24, 24});
+    m_iconButton->setIcon(QIcon::fromTheme("bluetooth"));
+    m_iconButton->setCheckable(true);
+    m_iconButton->setChecked(isOpen());
+    onPaletteChanged();
+
     // 添加中间的文本
     QWidget *textWidget = new QWidget(this);
     QVBoxLayout *textLayout = new QVBoxLayout(textWidget);
@@ -150,15 +101,15 @@ void BluetoothMainWidget::initUi()
     // 将所有的窗体都添加到主布局中
     mainLayout->setContentsMargins(10, 0, 10, 0);
     mainLayout->setSpacing(0);
-    mainLayout->addWidget(m_iconWidget);
+    mainLayout->addWidget(m_iconButton);
     mainLayout->addSpacing(10);
     mainLayout->addWidget(textWidget);
     mainLayout->addStretch();
     mainLayout->addWidget(expandWidget);
 
-    m_iconWidget->installEventFilter(this);
     m_expandLabel->installEventFilter(this);
     m_nameLabel->installEventFilter(this);
+    m_iconButton->installEventFilter(this);
 }
 
 void BluetoothMainWidget::initConnection()
@@ -171,6 +122,12 @@ void BluetoothMainWidget::initConnection()
 
     for (const Adapter *adapter : m_adapterManager->adapters())
         connect(adapter, &Adapter::poweredChanged, this, &BluetoothMainWidget::onAdapterChanged);
+
+    connect(m_iconButton, &DIconButton::clicked, this, [this](){
+        bool status = !(isOpen());
+        for (const Adapter *adapter : m_adapterManager->adapters())
+            m_adapterManager->setAdapterPowered(adapter, status);
+    });
 
     onAdapterChanged();
 }
@@ -206,5 +163,16 @@ void BluetoothMainWidget::onAdapterChanged()
     const QString& text = bluetoothIsOpen ? tr("Turn on") : tr("Turn off");
     QFontMetrics fmt{m_stateLabel->font()};
     m_stateLabel->setText(fmt.elidedText(text, Qt::TextElideMode::ElideRight,m_stateLabel->width()));
-    m_iconWidget->update();
+    m_iconButton->setChecked(bluetoothIsOpen);
+}
+
+void BluetoothMainWidget::onPaletteChanged()
+{
+    if (!m_iconButton)
+        return;
+
+    auto pa = m_iconButton->palette();
+    pa.setColor(QPalette::HighlightedText, pa.color(QPalette::Highlight));
+    m_iconButton->setPalette(pa);
+    m_iconButton->update();
 }

--- a/plugins/bluetooth/bluetoothmainwidget.h
+++ b/plugins/bluetooth/bluetoothmainwidget.h
@@ -6,11 +6,15 @@
 #ifndef BLUETOOTHMAINWIDGET_H
 #define BLUETOOTHMAINWIDGET_H
 
+#include <DIconButton>
+
 #include <QWidget>
 
 class AdaptersManager;
 class QLabel;
 class Adapter;
+
+DWIDGET_USE_NAMESPACE
 
 class BluetoothMainWidget : public QWidget
 {
@@ -37,10 +41,11 @@ private:
 
 private Q_SLOTS:
     void onAdapterChanged();
+    void onPaletteChanged();
 
 private:
     AdaptersManager *m_adapterManager;
-    QWidget *m_iconWidget;
+    DIconButton *m_iconButton;
     QLabel *m_nameLabel;
     QLabel *m_stateLabel;
     QLabel *m_expandLabel;

--- a/plugins/bluetooth/resources/bluetooth.qrc
+++ b/plugins/bluetooth/resources/bluetooth.qrc
@@ -46,5 +46,7 @@
         <file>light/icons/battery-090-symbolic_20px.svg</file>
         <file>light/icons/battery-100-symbolic_20px.svg</file>
         <file>light/icons/battery-unknow-symbolic_20px.svg</file>
+        <file alias="light/texts/bluetooth_16px.svg">light/buletooth_other_light.svg</file>
+        <file alias="dark/texts/bluetooth_16px.svg">dark/buletooth_other_dark.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
快捷面板中蓝牙图标和网络插件保持一致
- 大小一致 24x24
- 选中时高亮色填充
- 圆图标

Issue: https://github.com/linuxdeepin/developer-center/issues/7207