### PR TITLE
fix: dcc-dock-plugin icon tweak

### DIFF
--- a/frame/dbus/dbusdockadaptors.cpp
+++ b/frame/dbus/dbusdockadaptors.cpp
@@ -335,7 +335,14 @@ QIcon DBusDockAdaptors::getSettingIcon(PluginsItemInterface *plugin, QSize &pixm
     QIcon icon = plugin->icon(DockPart::DCCSetting, colorType);
     if (!icon.isNull()) {
         pixmapSize = iconSize(icon);
-        return icon;
+
+        QColor c = colorType == DGuiApplicationHelper::LightType ? Qt::black :Qt::white;
+        QPixmap pixmap = icon.pixmap(pixmapSize);
+        QPainter pa(&pixmap);
+        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
+        pa.fillRect(pixmap.rect(), c);
+
+        return pixmap;
     }
 
     // 如果插件中没有设置图标，则根据插件的类型，获取其他的图标

--- a/plugins/multitasking/multitaskingplugin.cpp
+++ b/plugins/multitasking/multitaskingplugin.cpp
@@ -145,12 +145,6 @@ QIcon MultitaskingPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::
     if (dockPart == DockPart::DCCSetting) {
         auto icon = QIcon::fromTheme("dcc-multitasking-view", QIcon(":/icons/dcc-multitasking-view.svg"));
         QPixmap pixmap = icon.pixmap(QSize(18, 18));
-        if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return pixmap;
-
-        QPainter pa(&pixmap);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pixmap.rect(), Qt::white);
         return pixmap;
     }
 

--- a/plugins/onboard/onboardplugin.cpp
+++ b/plugins/onboard/onboardplugin.cpp
@@ -146,16 +146,8 @@ void OnboardPlugin::pluginSettingsChanged()
 
 QIcon OnboardPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
 {
-    if (dockPart == DockPart::DCCSetting) {
-        if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return QIcon(":/icons/icon/dcc_keyboard.svg");
-
-        QPixmap pixmap(":/icons/icon/dcc_keyboard.svg");
-        QPainter pa(&pixmap);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pixmap.rect(), Qt::white);
-        return pixmap;
-    }
+    if (dockPart == DockPart::DCCSetting)
+        return QIcon(":/icons/icon/dcc_keyboard.svg");
 
     if (dockPart == DockPart::QuickPanel)
         return m_onboardItem->iconPixmap(QSize(24, 24), themeType);

--- a/plugins/show-desktop/showdesktopplugin.cpp
+++ b/plugins/show-desktop/showdesktopplugin.cpp
@@ -127,12 +127,6 @@ QIcon ShowDesktopPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::C
         auto loadsvg = []{ return ImageUtil::loadSvg(":/icons/dcc-show-desktop.svg", QSize(18, 18));};
         auto icon = QIcon::fromTheme("dcc-show-desktop", loadsvg());
         QPixmap pixmap = icon.pixmap(QSize(18, 18));
-        if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return pixmap;
-
-        QPainter pa(&pixmap);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pixmap.rect(), Qt::white);
         return pixmap;
     }
 

--- a/plugins/shutdown/shutdownplugin.cpp
+++ b/plugins/shutdown/shutdownplugin.cpp
@@ -277,13 +277,6 @@ QIcon ShutdownPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::Colo
     if (dockPart == DockPart::DCCSetting) {
         QString iconFile(":/icons/resources/icons/dcc_shutdown.svg");
         auto pixmap = ImageUtil::loadSvg(iconFile, QSize(18, 18));
-        if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return pixmap;
-
-        QPainter pa(&pixmap);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pixmap.rect(), Qt::white);
-
         return pixmap;
     }
 

--- a/plugins/trash/trashplugin.cpp
+++ b/plugins/trash/trashplugin.cpp
@@ -172,16 +172,10 @@ void TrashPlugin::pluginSettingsChanged()
     refreshPluginItemsVisible();
 }
 
-QIcon TrashPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType themeType)
+QIcon TrashPlugin::icon(const DockPart &dockPart, DGuiApplicationHelper::ColorType )
 {
     if (dockPart == DockPart::DCCSetting) {
         auto pixmap = ImageUtil::loadSvg(":/icons/dcc_trash.svg", QSize(18, 18));
-        if (themeType == DGuiApplicationHelper::ColorType::LightType)
-            return pixmap;
-
-        QPainter pa(&pixmap);
-        pa.setCompositionMode(QPainter::CompositionMode_SourceIn);
-        pa.fillRect(pixmap.rect(), Qt::white);
         return pixmap;
     }
 


### PR DESCRIPTION
控制中心中dock的插件统一混合颜色
暗色主题时填充白色，浅色主题填充黑色

Issue: https://github.com/linuxdeepin/developer-center/issues/6454