### PR TITLE
fix: duplicate tray for some app

### DIFF
--- a/frame/window/tray/tray_monitor.cpp
+++ b/frame/window/tray/tray_monitor.cpp
@@ -6,6 +6,7 @@
 #include "tray_monitor.h"
 #include "quicksettingcontroller.h"
 #include "pluginsiteminterface.h"
+#include "utils.h"
 
 TrayMonitor::TrayMonitor(QObject *parent)
     : QObject(parent)
@@ -110,6 +111,12 @@ void TrayMonitor::onSniItemsChanged()
                 qWarning() << __FUNCTION__ << "invalid sni service" << s;
                 continue;
             }
+
+            if (!Utils::IS_WAYLAND_DISPLAY && s.contains("/org/ayatana/NotificationItem/")) {
+                qDebug() << "SNI service path created by libayatana-appindicator, duplicate tray with legacy tray";
+                continue;
+            }
+
             Q_EMIT sniTrayAdded(s);
         }
     }

--- a/frame/window/tray/widgets/basetraywidget.cpp
+++ b/frame/window/tray/widgets/basetraywidget.cpp
@@ -13,7 +13,6 @@
 BaseTrayWidget::BaseTrayWidget(QWidget *parent, Qt::WindowFlags f)
     : QWidget(parent, f)
     , m_handleMouseReleaseTimer(new QTimer(this))
-    , m_ownerPID(0)
     , m_needShow(true)
 {
     m_handleMouseReleaseTimer->setSingleShot(true);
@@ -116,11 +115,6 @@ void BaseTrayWidget::resizeEvent(QResizeEvent *event)
     }
 }
 
-uint BaseTrayWidget::getOwnerPID()
-{
-    return this->m_ownerPID;
-}
-
 bool BaseTrayWidget::needShow()
 {
     return m_needShow;
@@ -138,9 +132,4 @@ void BaseTrayWidget::setNeedShow(bool needShow)
 #endif
 
     update();
-}
-
-void BaseTrayWidget::setOwnerPID(uint PID)
-{
-    this->m_ownerPID = PID;
 }

--- a/frame/window/tray/widgets/basetraywidget.h
+++ b/frame/window/tray/widgets/basetraywidget.h
@@ -28,7 +28,6 @@ public:
     virtual void sendClick(uint8_t mouseButton, int x, int y) = 0;
     virtual inline TrayType trayType() const { return TrayType::ApplicationTray; } // default is ApplicationTray
     virtual bool isValid() {return true;}
-    uint getOwnerPID();
     virtual bool needShow();
     virtual void setNeedShow(bool needShow);
     virtual QPixmap icon() = 0;
@@ -48,14 +47,12 @@ protected:
     void handleMouseRelease();
     const QRect perfectIconRect() const;
     void resizeEvent(QResizeEvent *event) override;
-    void setOwnerPID(uint PID);
 
 private:
     QTimer *m_handleMouseReleaseTimer;
 
     QPair<QPoint, Qt::MouseButton> m_lastMouseReleaseData;
 
-    uint m_ownerPID;
     bool m_needShow;
 };
 

--- a/frame/window/tray/widgets/snitrayitemwidget.cpp
+++ b/frame/window/tray/widgets/snitrayitemwidget.cpp
@@ -73,7 +73,6 @@ SNITrayItemWidget::SNITrayItemWidget(const QString &sniServicePath, QWidget *par
     m_dbusPath = pair.second;
 
     QDBusConnection conn = QDBusConnection::sessionBus();
-    setOwnerPID(conn.interface()->servicePid(m_dbusService));
 
     m_sniInter = new StatusNotifierItem(m_dbusService, m_dbusPath, QDBusConnection::sessionBus(), this);
     m_sniInter->setSync(false);

--- a/frame/window/tray/widgets/xembedtrayitemwidget.cpp
+++ b/frame/window/tray/widgets/xembedtrayitemwidget.cpp
@@ -76,7 +76,6 @@ XEmbedTrayItemWidget::XEmbedTrayItemWidget(quint32 winId, xcb_connection_t *cnn,
     , m_display(disp)
 {
     wrapWindow();
-    setOwnerPID(getWindowPID(winId));
 
     m_updateTimer = new QTimer(this);
     m_updateTimer->setInterval(100);
@@ -520,33 +519,4 @@ bool XEmbedTrayItemWidget::isBadWindow()
     free(clientGeom);
 
     return result;
-}
-
-uint XEmbedTrayItemWidget::getWindowPID(uint winId)
-{
-    const auto display = IS_WAYLAND_DISPLAY ? XOpenDisplay(nullptr) : QX11Info::display();
-    if (!display) {
-        qWarning() << "QX11Info::connection() is " << display;
-        return 0;
-    }
-
-    Atom nameAtom = XInternAtom(display, "_NET_WM_PID", 1);
-    Atom type;
-    int format, status;
-
-    unsigned long nitems, after;
-    unsigned char *data;
-    unsigned int pid = 0;
-
-    status = XGetWindowProperty(display, winId, nameAtom, 0, 1024, 0,
-            XInternAtom(display, "CARDINAL", 0), &type, &format, &nitems, &after, &data);
-    if (status == Success && data) {
-        pid = *((uint*)data);
-        XFree(data);
-    }
-
-    if (IS_WAYLAND_DISPLAY)
-        XCloseDisplay(display);
-
-    return pid;
 }

--- a/frame/window/tray/widgets/xembedtrayitemwidget.h
+++ b/frame/window/tray/widgets/xembedtrayitemwidget.h
@@ -28,7 +28,6 @@ public:
     void sendClick(uint8_t mouseButton, int x, int y) override;
 
     static QString toXEmbedKey(quint32 winId);
-    static uint getWindowPID(quint32 winId);
     static bool isXEmbedKey(const QString &itemKey);
     virtual bool isValid() override {return m_valid;}
     QPixmap icon() override;


### PR DESCRIPTION
some gtk apps use libayatana-appindicator create tray will create xembed and sni duplicate tray not show sni tray which path contains /org/ayatana/NotificationItem/ created by ayatana-appindicator

log: not show ayatana-appindicator sni tray on xorg