### PR TITLE
fix: wine app menu obscured by popup widget

### DIFF
--- a/frame/window/tray/widgets/expandiconwidget.cpp
+++ b/frame/window/tray/widgets/expandiconwidget.cpp
@@ -135,7 +135,7 @@ TrayGridWidget *ExpandIconWidget::popupTrayView()
     TrayModel *trayModel = TrayModel::getIconModel();
     gridParentView->setTrayGridView(trayView);
 
-    gridParentView->setWindowFlags(Qt::FramelessWindowHint | Qt::ToolTip | Qt::WindowStaysOnTopHint | Qt::WindowDoesNotAcceptFocus);
+    gridParentView->setWindowFlags(Qt::WindowDoesNotAcceptFocus);
     trayView->setModel(trayModel);
     trayView->setItemDelegate(trayDelegate);
     trayView->setSpacing(ITEM_SPACING);


### PR DESCRIPTION
remove ToolTip windowflag

Bug: https://pms.uniontech.com/bug-view-239173.html
Issue: https://github.com/linuxdeepin/developer-center/issues/7612